### PR TITLE
Avoid out-of-bounds array access.

### DIFF
--- a/src/adl.cpp
+++ b/src/adl.cpp
@@ -2379,7 +2379,7 @@ bool CadlPlayer::load(const std::string &filename, const CFileProvider &fp)
   // 	_soundFileLoaded = file;
 
   // find last subsong
-  for(int i = 199; i >= 0; i--)
+  for(int i = 119; i >= 0; i--)
     if(_trackEntries[i] != 0xff) {
       numsubsongs = i + 1;
       break;


### PR DESCRIPTION
See #4.