### PR TITLE
Fix loudness music files always playing at 70hz

### DIFF
--- a/src/lds.h
+++ b/src/lds.h
@@ -32,7 +32,7 @@ class CldsPlayer: public CPlayer
   bool load(const std::string &filename, const CFileProvider &fp);
   virtual bool update();
   virtual void rewind(int subsong = -1);
-  float getrefresh() { return 70.0f; }
+  float getrefresh() { return 1193182.0f / speed; }
 
   std::string gettype() { return std::string("LOUDNESS Sound System"); }
   unsigned int getorders() { return numposi; }


### PR DESCRIPTION
Loudness Sound System files are fixed to be replayed at 70hz but there are files which need to be replayed at 60hz.
This uses the replay rate stored inside the file instead of forcing 70hz