### PR TITLE
CRealopl support in Linux 

### DIFF
--- a/src/realopl.cpp
+++ b/src/realopl.cpp
@@ -17,71 +17,63 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * realopl.cpp - Real hardware OPL, by Simon Peter <dn.tlp@gmx.net>
+ *             - Linux support by Tomas Pollak <tomas@forkhq.com>
  */
 
-#ifdef _MSC_VER			// Microsoft Visual C++
-#if (_MSC_VER >= 1900) // VS2015+
-// _inp and _outp are no longer part of the C runtime from VS2015/Win8.1
-int INP(int dummy) { return 0; }
-void OUTP(int dummy, int dummy2) { return; }
-#else // _MSC_VER < 1900
-#	include <conio.h>
-#	define INP	_inp
-#	define OUTP	_outp
-#endif // _MSC_VER < 1900
-#elif defined(__WATCOMC__)	// Watcom C/C++ and OpenWatcom
-#	include <conio.h>
-#	define INP	inp
-#	define OUTP	outp
-#elif defined(WIN32) && defined(__MSVCRT__) && defined(__MINGW32__)	// MinGW32
-/*
-int __cdecl _inp(unsigned short);
-int __cdecl _outp(unsigned short, int);
-#	define INP	_inp
-#	define OUTP	_outp
-*/
-#	define INP		inb
-#	define OUTP(reg, val)	outb(val, reg)
-#elif defined(DJGPP)		// DJGPP
-#	include <pc.h>
-#	define INP	inportb
-#	define OUTP	outportb
+#ifdef _MSC_VER     // Microsoft Visual C++
+  #if (_MSC_VER >= 1900) // VS2015+
+  // _inp and _outp are no longer part of the C runtime from VS2015/Win8.1
+  int INP(int dummy) { return 0; }
+  void OUTP(int dummy, int dummy2) { return; }
+  #else // _MSC_VER < 1900
+  # include <conio.h>
+  # define INP  _inp
+  # define OUTP _outp
+  #endif // _MSC_VER < 1900
+#elif defined(__WATCOMC__)  // Watcom C/C++ and OpenWatcom
+  # include <conio.h>
+  # define INP  inp
+  # define OUTP outp
+#elif defined(WIN32) && defined(__MSVCRT__) && defined(__MINGW32__) // MinGW32
+  # define INP    inb
+  # define OUTP(reg, val) outb(val, reg)
+#elif defined(DJGPP)    // DJGPP
+  # include <pc.h>
+  # define INP  inportb
+  # define OUTP outportb
 #elif defined(linux)
-# include <sys/io.h>
-# define INP inb
-# define OUTP(reg,val) outb(val,reg)
-#else				// no support on other platforms
-#	define INP(reg)		0
-#	define OUTP(reg, val)
+  # include <sys/io.h>
+  # define INP inb
+  # define OUTP(reg,val) outb(val,reg)
+#else // no support on other platforms
+  # define INP(reg)   0
+  # define OUTP(reg, val)
 #endif
 
 #include "realopl.h"
 
-#define SHORTDELAY		6	// short delay in I/O port-reads after OPL hardware output
-#define LONGDELAY		35	// long delay in I/O port-reads after OPL hardware output
+#define SHORTDELAY  6   // short delay in I/O port-reads after OPL hardware output
+#define LONGDELAY   35  // long delay in I/O port-reads after OPL hardware output
 
 const unsigned char CRealopl::op_table[9] =
-  {0x00, 0x01, 0x02, 0x08, 0x09, 0x0a, 0x10, 0x11, 0x12};
+{0x00, 0x01, 0x02, 0x08, 0x09, 0x0a, 0x10, 0x11, 0x12};
 
 #if defined(WIN32) && defined(__MINGW32__)
-static __inline unsigned char inb(unsigned short int port)
-{
+static __inline unsigned char inb(unsigned short int port) {
   unsigned char _v;
 
   __asm__ __volatile__ ("inb %w1,%0":"=a" (_v):"Nd" (port));
   return _v;
 }
 
-static __inline void outb(unsigned char value, unsigned short int port)
-{
+static __inline void outb(unsigned char value, unsigned short int port) {
   __asm__ __volatile__ ("outb %b0,%w1": :"a" (value), "Nd" (port));
 }
 #endif
 
 CRealopl::CRealopl(unsigned short initport)
-  : adlport(initport), hardvol(0), bequiet(false), nowrite(false)
-{
-  for(int i=0;i<22;i++) {
+  : adlport(initport), hardvol(0), bequiet(false), nowrite(false) {
+  for (int i = 0; i < 22; i++) {
     hardvols[0][i][0] = 0;
     hardvols[0][i][1] = 0;
     hardvols[1][i][0] = 0;
@@ -91,141 +83,155 @@ CRealopl::CRealopl(unsigned short initport)
   currType = TYPE_OPL3;
 }
 
-bool CRealopl::harddetect()
-{
-  unsigned char		stat1, stat2, i;
-  unsigned short	adp = (currChip == 0 ? adlport : adlport + 2);
+bool CRealopl::harddetect() {
+  unsigned char   stat1, stat2, i;
+  unsigned short  adp = (currChip == 0 ? adlport : adlport + 2);
 
-  hardwrite(4,0x60); hardwrite(4,0x80);
+  hardwrite(4, 0x60); hardwrite(4, 0x80);
   stat1 = INP(adp);
-  hardwrite(2,0xff); hardwrite(4,0x21);
-  for(i=0;i<80;i++)			// wait for adlib
-    INP(adp);
-  stat2 = INP(adp);
-  hardwrite(4,0x60); hardwrite(4,0x80);
+  hardwrite(2, 0xff); hardwrite(4, 0x21);
 
-  if(((stat1 & 0xe0) == 0) && ((stat2 & 0xe0) == 0xc0))
+  for (i = 0; i < 80; i++) // wait for adlib
+    INP(adp);
+
+  stat2 = INP(adp);
+  hardwrite(4, 0x60); hardwrite(4, 0x80);
+
+  if (((stat1 & 0xe0) == 0) && ((stat2 & 0xe0) == 0xc0))
     return true;
   else
     return false;
 }
 
-bool CRealopl::detect()
-{
-  unsigned char	stat;
-
-#ifdef linux // see whether we can access the port
-  if ((ioperm(adlport, 2, 1) != 0) || (ioperm(adlport + 2, 2, 1) != 0)) {
-    return false;
-  }
-#endif
+bool CRealopl::detect() {
+  unsigned char stat;
 
   setchip(0);
-  if(harddetect()) {
+
+  if (harddetect()) {
     // is at least OPL2, check for OPL3
     currType = TYPE_OPL2;
 
     stat = INP(adlport);
-    if(stat & 6) {
+
+    if (stat & 6) {
       // not OPL3, try dual-OPL2
       setchip(1);
-      if(harddetect())
-	currType = TYPE_DUAL_OPL2;
-    } else
+
+      if (harddetect())
+        currType = TYPE_DUAL_OPL2;
+
+    } else {
       currType = TYPE_OPL3;
+    }
 
     setchip(0);
     return true;
-  } else
+
+  } else {
     return false;
+  }
 }
 
-void CRealopl::setvolume(int volume)
-{
+void CRealopl::setvolume(int volume) {
   int i, j;
 
   hardvol = volume;
-  for(j = 0; j < 2; j++)
-    for(i = 0; i < 9; i++) {
-      hardwrite(0x43+op_table[i],((hardvols[j][op_table[i]+3][0] & 63) + volume) > 63 ? 63 : hardvols[j][op_table[i]+3][0] + volume);
-      if(hardvols[j][i][1] & 1)	// modulator too?
-	hardwrite(0x40+op_table[i],((hardvols[j][op_table[i]][0] & 63) + volume) > 63 ? 63 : hardvols[j][op_table[i]][0] + volume);
+
+  for (j = 0; j < 2; j++)
+    for (i = 0; i < 9; i++) {
+      hardwrite(0x43 + op_table[i], ((hardvols[j][op_table[i] + 3][0] & 63) + volume) > 63 ? 63 : hardvols[j][op_table[i] + 3][0] + volume);
+
+      if (hardvols[j][i][1] & 1) // modulator too?
+        hardwrite(0x40 + op_table[i], ((hardvols[j][op_table[i]][0] & 63) + volume) > 63 ? 63 : hardvols[j][op_table[i]][0] + volume);
     }
 }
 
-void CRealopl::setquiet(bool quiet)
-{
+void CRealopl::setquiet(bool quiet) {
   bequiet = quiet;
 
-  if(quiet) {
+  if (quiet) {
     oldvol = hardvol;
     setvolume(63);
+
   } else
     setvolume(oldvol);
 }
 
-void CRealopl::hardwrite(int reg, int val)
-{
-  int 			i;
-  unsigned short	adp = (currChip == 0 ? adlport : adlport + 2);
+void CRealopl::hardwrite(int reg, int val) {
+  int i;
+  unsigned short adp = (currChip == 0 ? adlport : adlport + 2);
 
-  if(nowrite)
+  if (nowrite)
     return;
 
-  OUTP(adp,reg);		// set register
-  for(i=0;i<SHORTDELAY;i++)	// wait for adlib
+#ifdef linux // see whether we can access the port
+  if (!gotperms) {
+    if ((ioperm(adlport, 2, 1) != 0) || (ioperm(adlport + 2, 2, 1) != 0)) {
+      return;
+    }
+    gotperms = true;
+  }
+#endif
+
+  OUTP(adp, reg);   // set register
+
+  for (i = 0; i < SHORTDELAY; i++) // wait for adlib
     INP(adp);
-  OUTP(adp+1,val);		// set value
-  for(i=0;i<LONGDELAY;i++)	// wait for adlib
+
+  OUTP(adp + 1, val); // set value
+
+  for (i = 0; i < LONGDELAY; i++) // wait for adlib
     INP(adp);
 }
 
-void CRealopl::write(int reg, int val)
-{
+void CRealopl::write(int reg, int val) {
   int i;
 
-  if(nowrite)
+  if (nowrite)
     return;
 
-  if(currType == TYPE_OPL2 && currChip > 0)
+  if (currType == TYPE_OPL2 && currChip > 0)
     return;
 
-  if(bequiet && (reg >= 0xb0 && reg <= 0xb8))	// filter all key-on commands
+  if (bequiet && (reg >= 0xb0 && reg <= 0xb8)) // filter all key-on commands
     val &= ~32;
-  if(reg >= 0x40 && reg <= 0x55)		// cache volumes
-    hardvols[currChip][reg-0x40][0] = val;
-  if(reg >= 0xc0 && reg <= 0xc8)
-    hardvols[currChip][reg-0xc0][1] = val;
-  if(hardvol)					// reduce volume
-    for(i=0;i<9;i++) {
-      if(reg == 0x43 + op_table[i])
-	val = ((val & 63) + hardvol) > 63 ? 63 : val + hardvol;
-      else
-	if((reg == 0x40 + op_table[i]) && (hardvols[currChip][i][1] & 1))
-	  val = ((val & 63) + hardvol) > 63 ? 63 : val + hardvol;
+
+  if (reg >= 0x40 && reg <= 0x55)   // cache volumes
+    hardvols[currChip][reg - 0x40][0] = val;
+
+  if (reg >= 0xc0 && reg <= 0xc8)
+    hardvols[currChip][reg - 0xc0][1] = val;
+
+  if (hardvol)        // reduce volume
+    for (i = 0; i < 9; i++) {
+      if (reg == 0x43 + op_table[i])
+        val = ((val & 63) + hardvol) > 63 ? 63 : val + hardvol;
+      else if ((reg == 0x40 + op_table[i]) && (hardvols[currChip][i][1] & 1))
+        val = ((val & 63) + hardvol) > 63 ? 63 : val + hardvol;
     }
 
-  hardwrite(reg,val);
+  hardwrite(reg, val);
 }
 
-void CRealopl::init()
-{
+void CRealopl::init() {
   int i, j;
 
-  for(j = 0; j < 2; j++) {
+  for (j = 0; j < 2; j++) {
     setchip(j);
 
     // set all registers to zero
-    for (i = 0; i < 256;i++) {
+    for (i = 0; i < 256; i++) {
       write(i, 0);
     }
 
-    for(i=0;i<9;i++) {				// stop instruments
-      hardwrite(0xb0 + i,0);			// key off
-      hardwrite(0x80 + op_table[i],0xff);	// fastest release
+    // stop instruments
+    for (i = 0; i < 9; i++) {
+      hardwrite(0xb0 + i, 0);               // key off
+      hardwrite(0x80 + op_table[i], 0xff);  // fastest release
     }
 
-    hardwrite(0xbd,0);	// clear misc. register
+    hardwrite(0xbd, 0); // clear misc. register
   }
 
   setchip(0);

--- a/src/realopl.cpp
+++ b/src/realopl.cpp
@@ -215,6 +215,11 @@ void CRealopl::init()
   for(j = 0; j < 2; j++) {
     setchip(j);
 
+    // set all registers to zero
+    for (i = 0; i < 256;i++) {
+      write(i, 0);
+    }
+
     for(i=0;i<9;i++) {				// stop instruments
       hardwrite(0xb0 + i,0);			// key off
       hardwrite(0x80 + op_table[i],0xff);	// fastest release

--- a/src/realopl.cpp
+++ b/src/realopl.cpp
@@ -115,7 +115,7 @@ bool CRealopl::detect()
   unsigned char	stat;
 
 #ifdef linux // see whether we can access the port
-  if ((ioperm(adlport, 2, 1) != 0) && (ioperm(adlport + 2, 2, 1) != 0)) {
+  if ((ioperm(adlport, 2, 1) != 0) || (ioperm(adlport + 2, 2, 1) != 0)) {
     return false;
   }
 #endif

--- a/src/realopl.h
+++ b/src/realopl.h
@@ -1,22 +1,23 @@
 /*
  * AdPlug - Replayer for many OPL2/OPL3 audio file formats.
  * Copyright (C) 1999 - 2005 Simon Peter <dn.tlp@gmx.net>, et al.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * realopl.h - Real hardware OPL, by Simon Peter <dn.tlp@gmx.net>
+ *           - Linux support by Tomas Pollak <tomas@forkhq.com>
  */
 
 #ifndef H_ADPLUG_REALOPL
@@ -24,49 +25,50 @@
 
 #include "opl.h"
 
-#define DFL_ADLIBPORT	0x388		// default adlib baseport
+#define DFL_ADLIBPORT 0x388 // default adlib baseport
 
-class CRealopl: public Copl
-{
- public:	
-  CRealopl(unsigned short initport = DFL_ADLIBPORT);	// initport = OPL2 hardware baseport
+class CRealopl: public Copl {
+ public:
+  CRealopl(unsigned short initport = DFL_ADLIBPORT); // initport = OPL2 hardware baseport
 
-  bool detect();			// returns true if adlib compatible board is found, else false
-  void setvolume(int volume);		// set adlib master volume (0 - 63) 0 = loudest, 63 = softest
-  void setquiet(bool quiet = true);	// sets the OPL2 quiet, while still writing to the registers
-  void setport(unsigned short port)	// set new OPL2 hardware baseport
-    {
-      adlport = port;
-    }
-  void setnowrite(bool nw = true)	// set hardware write status
-    {
-      nowrite = nw;
-    }
+  bool detect();                      // returns true if adlib compatible board is found, else false
+  void setvolume(int volume);         // set adlib master volume (0 - 63) 0 = loudest, 63 = softest
+  void setquiet(bool quiet = true);   // sets the OPL2 quiet, while still writing to the registers
 
-  int getvolume()			// get adlib master volume
-    {
-      return hardvol;
-    }
+  void setport(unsigned short port) { // set new OPL2 hardware baseport
+    adlport = port;
+  }
+
+  void setnowrite(bool nw = true) { // set hardware write status
+    nowrite = nw;
+  }
+
+  int getvolume() { // get adlib master volume
+    return hardvol;
+  }
 
   // template methods
   void write(int reg, int val);
   void init();
-  void settype(ChipType type)
-    {
-      currType = type;
-    }
+  void settype(ChipType type) {
+    currType = type;
+  }
 
  protected:
-  void hardwrite(int reg, int val);		// write to OPL2 hardware registers
-  bool harddetect();				// do real hardware detection
+  void hardwrite(int reg, int val);   // write to OPL2 hardware registers
+  bool harddetect();                  // do real hardware detection
 
-  static const unsigned char op_table[9];	// the 9 operators as expected by the OPL2
+  // the 9 operators as expected by the OPL2
+  static const unsigned char op_table[9];
 
-  unsigned short	adlport;		// adlib hardware baseport
-  int			hardvol, oldvol;	// hardware master volume
-  bool			bequiet;		// quiet status cache
-  char			hardvols[2][22][2];	// volume cache
-  bool			nowrite;		// don't write to hardware, if true
+  unsigned short  adlport;            // adlib hardware baseport
+  int             hardvol, oldvol;    // hardware master volume
+  bool            bequiet;            // quiet status cache
+  char            hardvols[2][22][2]; // volume cache
+  bool            nowrite;            // don't write to hardware, if true
+#ifdef linux
+  bool            gotperms;           // if we've requested ioperms yet
+#endif
 };
 
 #endif


### PR DESCRIPTION
This PR allows talking to an OPL chip directly in Linux via the CRealopl class. 

Given that we need to ask for permission before sending any commands, I added a `gotperms` flag to check whether we've already done so or not, so we only request `ioperms` once.

I also noticed that the CrawPlayer wouldn't produce any sound without first setting all registers to zero, [as the DRO player does](https://github.com/adplug/adplug/blob/master/src/dro.cpp#L144-L151) so I also added that logic as part of CRealopl's init logic -- didn't want to fiddle with the players. :)

Finally, I also cleaned up and reformatted part of the code. I didn't see any pattern with regards to code style so I hope this is OK.