### PR TITLE
Fix `-Waggressive-loop-optimizations`

### DIFF
--- a/src/fmopl.c
+++ b/src/fmopl.c
@@ -602,7 +602,7 @@ static void init_timetables( FM_OPL *OPL , int ARRATE , int DRRATE )
 		OPL->AR_TABLE[i] = rate / ARRATE;
 		OPL->DR_TABLE[i] = rate / DRRATE;
 	}
-	for (i = 60;i < 76;i++)
+	for (i = 60;i < 75;i++)
 	{
 		OPL->AR_TABLE[i] = EG_AED-1;
 		OPL->DR_TABLE[i] = OPL->DR_TABLE[60];


### PR DESCRIPTION
* fmopl.c:607:20: warning: iteration 15 invokes undefined behavior [-Waggressive-loop-optimizations]
     OPL->AR_TABLE[i] = EG_AED-1;
     ~~~~~~~~~~~~~~~~~^~~~~~~~~~
  fmopl.c:605:2: note: within this loop
    for (i = 60;i < 76;i++)
    ^~~
* AR_TABLE is defined as an INT32[75] array, and overrunning
  the bounds invokes undefined behavior.