### PR TITLE
Remove UTF-8 BOM, for compatibility with older compilers

### DIFF
--- a/src/herad.cpp
+++ b/src/herad.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Adplug - Replayer for many OPL2/OPL3 audio file formats.
  * Copyright (C) 1999 - 2008 Simon Peter <dn.tlp@gmx.net>, et al.
  * 

--- a/src/herad.h
+++ b/src/herad.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Adplug - Replayer for many OPL2/OPL3 audio file formats.
  * Copyright (C) 1999 - 2005 Simon Peter <dn.tlp@gmx.net>, et al.
  * 


### PR DESCRIPTION
Hi,

Some operating systems still use older compilers such as GCC 4.2.1, which choke on UTF-8 BOMs.

The following diff fixes this. Tested on OpenBSD, where some archs still use GCC 4.2.1 as their main compiler.

Otherwise, you get this error:
```
In file included from src/adplug.cpp:84:
src/herad.h:1: error: stray '\357' in program
src/herad.h:1: error: stray '\273' in program
src/herad.h:1: error: stray '\277' in program
```

https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/audio/adplug/patches/
http://build-failures.rhaalovely.net/powerpc/2018-05-13/audio/adplug.log