### PR TITLE
Build NuGet packages with VS2017 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 2.3.2-beta{build}
+image: Visual Studio 2017
 
 install:
 - ps: >-
@@ -49,13 +50,15 @@ before_build:
 
 build_script:
 - cmd: >-
-    "%VS140COMNTOOLS%\VsMSBuildCmd.bat"
+    "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+
+    "%VS150COMNTOOLS%\VsMSBuildCmd.bat"
 
     appveyor-retry nuget restore contrib\vs2015\vs2015.sln
 
     appveyor-retry nuget update contrib\vs2015\vs2015.sln
 
-    FOR %%T IN (v140,v120_xp) DO ( FOR %%P IN (x86,x64) DO ( FOR %%C IN (Debug,Release) DO ( FOR %%F IN (adplug,emutest,crctest,playertest) DO ( echo *** Building %%F as %%T/%%P/%%C *** && msbuild contrib\vs2015\%%F\%%F.vcxproj /p:Configuration=%%C /p:Platform=%%P /p:PlatformToolset=%%T /p:SolutionDir=..\ /v:minimal /nologo || EXIT 1 ) ) ) )
+    FOR %%T IN (v141,v140,v120_xp) DO ( FOR %%P IN (x86,x64) DO ( FOR %%C IN (Debug,Release) DO ( FOR %%F IN (adplug,emutest,crctest,playertest) DO ( echo *** Building %%F as %%T/%%P/%%C *** && msbuild contrib\vs2015\%%F\%%F.vcxproj /p:Configuration=%%C /p:Platform=%%P /p:PlatformToolset=%%T /p:SolutionDir=..\ /v:minimal /nologo || EXIT 1 ) ) ) )
 
 before_deploy:
 - ps: >-

--- a/contrib/vs2015/adplug.autopkg.template
+++ b/contrib/vs2015/adplug.autopkg.template
@@ -1,6 +1,6 @@
 #define {
 	// Must match the PlatformToolset options in appveyor.yml
-	toolsets: "v140,v120_xp";
+	toolsets: "v141,v140,v120_xp";
 }
 
 configurations {

--- a/contrib/vs2015/adplug.autopkg.template
+++ b/contrib/vs2015/adplug.autopkg.template
@@ -31,7 +31,7 @@ nuget {
 	}
 	dependencies {
 		packages : {
-			libbinio/1.4.16
+			libbinio/1.4.20
 		};
 	}
 	files {

--- a/contrib/vs2015/adplug/adplug.vcxproj
+++ b/contrib/vs2015/adplug/adplug.vcxproj
@@ -291,12 +291,12 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\libbinio.1.4.16\build\native\libbinio.targets" Condition="Exists('..\packages\libbinio.1.4.16\build\native\libbinio.targets')" />
+    <Import Project="..\packages\libbinio.1.4.20\build\native\libbinio.targets" Condition="Exists('..\packages\libbinio.1.4.20\build\native\libbinio.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\libbinio.1.4.16\build\native\libbinio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libbinio.1.4.16\build\native\libbinio.targets'))" />
+    <Error Condition="!Exists('..\packages\libbinio.1.4.20\build\native\libbinio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libbinio.1.4.20\build\native\libbinio.targets'))" />
   </Target>
 </Project>

--- a/contrib/vs2015/adplug/packages.config
+++ b/contrib/vs2015/adplug/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="libbinio" version="1.4.16" targetFramework="native" />
+  <package id="libbinio" version="1.4.20" targetFramework="native" />
 </packages>

--- a/contrib/vs2015/crctest/crctest.vcxproj
+++ b/contrib/vs2015/crctest/crctest.vcxproj
@@ -158,12 +158,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\libbinio.1.4.16\build\native\libbinio.targets" Condition="Exists('..\packages\libbinio.1.4.16\build\native\libbinio.targets')" />
+    <Import Project="..\packages\libbinio.1.4.20\build\native\libbinio.targets" Condition="Exists('..\packages\libbinio.1.4.20\build\native\libbinio.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\libbinio.1.4.16\build\native\libbinio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libbinio.1.4.16\build\native\libbinio.targets'))" />
+    <Error Condition="!Exists('..\packages\libbinio.1.4.20\build\native\libbinio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libbinio.1.4.20\build\native\libbinio.targets'))" />
   </Target>
 </Project>

--- a/contrib/vs2015/crctest/packages.config
+++ b/contrib/vs2015/crctest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="libbinio" version="1.4.16" targetFramework="native" />
+  <package id="libbinio" version="1.4.20" targetFramework="native" />
 </packages>

--- a/contrib/vs2015/playertest/packages.config
+++ b/contrib/vs2015/playertest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="libbinio" version="1.4.16" targetFramework="native" />
+  <package id="libbinio" version="1.4.20" targetFramework="native" />
 </packages>

--- a/contrib/vs2015/playertest/playertest.vcxproj
+++ b/contrib/vs2015/playertest/playertest.vcxproj
@@ -166,12 +166,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\libbinio.1.4.16\build\native\libbinio.targets" Condition="Exists('..\packages\libbinio.1.4.16\build\native\libbinio.targets')" />
+    <Import Project="..\packages\libbinio.1.4.20\build\native\libbinio.targets" Condition="Exists('..\packages\libbinio.1.4.20\build\native\libbinio.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\libbinio.1.4.16\build\native\libbinio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libbinio.1.4.16\build\native\libbinio.targets'))" />
+    <Error Condition="!Exists('..\packages\libbinio.1.4.20\build\native\libbinio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libbinio.1.4.20\build\native\libbinio.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
Adds VS platform toolset v141 to the AppVeyor builds which allows building on VS2017 with the v141 toolset. Fixes #68