### PR TITLE
Added user configurable frequency offset for surroundopl. 

### DIFF
--- a/src/opl.h
+++ b/src/opl.h
@@ -60,6 +60,9 @@ class Copl
 
   // Emulation only: fill buffer
   virtual void update(short *buf, int samples) {}
+  
+  // Set surroundopl offset
+  virtual void set_offset(double offset) {}
 
  protected:
   int		currChip;		// currently selected OPL chip number

--- a/src/surroundopl.cpp
+++ b/src/surroundopl.cpp
@@ -44,6 +44,9 @@ CSurroundopl::CSurroundopl(COPLprops *a, COPLprops *b, bool output16bit)
 
 	this->lbuf = new short[this->bufsize];
 	this->rbuf = new short[this->bufsize];
+	
+	// Default frequency offset for surroundopl is defined by FREQ_OFFSET. 
+	this->offset = FREQ_OFFSET;
 };
 
 CSurroundopl::~CSurroundopl()
@@ -127,7 +130,7 @@ void CSurroundopl::write(int reg, int val)
 		// Adjust the frequency and calculate the new FNum
 		//double dbNewFNum = (dbOriginalFreq+(dbOriginalFreq/FREQ_OFFSET)) / (50000.0 * pow(2, iNewBlock - 20));
 		//#define calcFNum() ((dbOriginalFreq+(dbOriginalFreq/FREQ_OFFSET)) / (50000.0 * pow(2, iNewBlock - 20)))
-		#define calcFNum() ((dbOriginalFreq+(dbOriginalFreq/FREQ_OFFSET)) / (49716.0 * pow(2.0, iNewBlock - 20)))
+		#define calcFNum() ((dbOriginalFreq+(dbOriginalFreq/this->offset)) / (49716.0 * pow(2.0, iNewBlock - 20)))
 		double dbNewFNum = calcFNum();
 
 		// Make sure it's in range for the OPL chip
@@ -240,4 +243,12 @@ void CSurroundopl::setchip(int n)
 {
 	this->oplA.opl->setchip(n);
 	this->oplB.opl->setchip(n);
+}
+
+void CSurroundopl::set_offset(double offset)
+{
+	if (offset != 0)
+	{
+		this->offset = offset;
+	}
 }

--- a/src/surroundopl.h
+++ b/src/surroundopl.h
@@ -59,6 +59,7 @@ class CSurroundopl: public Copl
 		uint8_t iTweakedFMReg[2][256];
 		uint8_t iCurrentTweakedBlock[2][9]; // Current value of the Block in the tweaked OPL chip
 		uint8_t iCurrentFNum[2][9];         // Current value of the FNum in the tweaked OPL chip
+		double offset;                      // User configurable frequency offset for surroundopl
 
 	public:
 
@@ -71,6 +72,7 @@ class CSurroundopl: public Copl
 
 		void init();
 		void setchip(int n);
+		void set_offset(double offset);
 };
 
 #endif


### PR DESCRIPTION
Hello! 

Please refer to the issue of "User configurable FREQ_OFFSET? #70 ". For some music tracks, perhaps it is necessary to set a surroundopl frequency offset value greater than 128 in order to avoid "distortion" of certain voice. So I think a user configurable frequency offset for surroundopl is pretty useful. 

I have added the feature of user configurable freq offset. Now the default frequency offset value is still defined by FREQ_OFFSET, which is 128. Frontend developers could set a new frequency offset value with something like: 
`opl->set_offset(cfg.offset);`