### PR TITLE
CNemuopl::init should call OPL3_Reset.

### DIFF
--- a/src/nemuopl.cpp
+++ b/src/nemuopl.cpp
@@ -30,6 +30,7 @@ CNemuopl::CNemuopl(int rate)
   opl = new opl3_chip();
   OPL3_Reset(opl, rate);
   currType = TYPE_OPL2;
+  samplerate = rate;
 }
 
 CNemuopl::~CNemuopl()
@@ -47,4 +48,8 @@ void CNemuopl::write(int reg, int val)
   OPL3_WriteRegBuffered(opl, (currChip << 8) | reg, val);
 }
 
-void CNemuopl::init() {}
+void CNemuopl::init()
+{
+  OPL3_Reset(opl, samplerate);
+  currChip = 0;
+}

--- a/src/nemuopl.h
+++ b/src/nemuopl.h
@@ -40,6 +40,7 @@ public:
 
 private:
   opl3_chip*	opl;
+  int			samplerate;
 };
 
 #endif


### PR DESCRIPTION
Otherwise the emulator doesn't reset when the song rewinds, etc.

Similar code was already in CEmuopl::init.