### PR TITLE
Another ADL fix

### DIFF
--- a/src/adl.cpp
+++ b/src/adl.cpp
@@ -2320,6 +2320,10 @@ void CadlPlayer::play(uint16_t track) {
     _sfxPlayingSound = -1;
   }
 
+  // Verify that the sound/program offset is valid.
+  // KYRA3A.ADL subsong 2 points to sound 2, but the offset sound 2 is 0xffff.
+  if (READ_LE_UINT16(_soundDataPtr + 2 * soundId) == 0xffff)
+    return;
   int chan = _driver->callback(9, soundId, int(0));
 
   if (chan != 9) {


### PR DESCRIPTION
KYRA3A.ADL subsong 2 points to sound 2, but the offset sound 2 is 0xffff.
KYRA3A.ADL was mentioned in issue #6 

Added a check for that and no more access violations for it.
Subsong 3, though, reports that it's 10 minutes long...