### PR TITLE
Unaligned access

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -160,7 +160,8 @@ pkginclude_HEADERS = \
 	src/cmfmcsop.h \
 	src/vgm.h \
 	src/sop.h \
-	src/herad.h
+	src/herad.h \
+	src/load_helper.h
 
 #############
 # adplugdb/ #

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,8 @@ AC_LANG([C++])
 AX_COMPILER_VENDOR
 AX_COMPILER_VERSION
 
+AC_C_BIGENDIAN
+
 AS_IF([test "x${enable_flags_setting}" = "xyes" && test "x${enable_debug}" = "xno"], [
     AC_LANG([C])
     AX_APPEND_COMPILE_FLAGS([-O2 -pipe], [CFLAGS])

--- a/src/load_helper.h
+++ b/src/load_helper.h
@@ -1,0 +1,58 @@
+#ifndef ADPLUG_LOAD_HELPER_H
+#define ADPLUG_LOAD_HELPER_H
+
+#include <cstring>
+#include <stdint.h>
+
+inline uint16_t adplug_byteswap(const uint16_t val)
+{
+  return
+    ((val & 0x00FF) << 8) |
+    ((val & 0xFF00) >> 8);
+}
+
+inline uint32_t adplug_byteswap(const uint32_t val)
+{
+  return
+    ((val & 0x000000FF) << 24) |
+    ((val & 0x0000FF00) <<  8) |
+    ((val & 0x00FF0000) >>  8) |
+    ((val & 0xFF000000) >> 24);
+}
+
+// In many cases, we need to load a uint16_t/uint32_t from a (possibly)
+// unaligned byte stream. In order to avoid undefined behavior, we have to use
+// memcpy as the only portable way to perform type punning. See:
+//   https://blog.regehr.org/archives/959
+template <typename T>
+static inline T load_unaligned_impl(const unsigned char* src, const bool big_endian)
+{
+  T result;
+  std::memcpy(&result, src, sizeof(T));
+
+#ifdef WORDS_BIGENDIAN
+  // big-endian CHOST
+  if (!big_endian)
+#else
+  // little-endian CHOST
+  if (big_endian)
+#endif
+  {
+    // have to do a byte-swap
+    result = adplug_byteswap(result);
+  }
+
+  return result;
+}
+
+inline uint16_t u16_unaligned(const unsigned char* src, const bool big_endian = false)
+{
+  return load_unaligned_impl<uint16_t>(src, big_endian);
+}
+
+inline uint32_t u32_unaligned(const unsigned char* src, const bool big_endian = false)
+{
+  return load_unaligned_impl<uint32_t>(src, big_endian);
+}
+
+#endif  // ADPLUG_LOAD_HELPER_H

--- a/src/mid.cpp
+++ b/src/mid.cpp
@@ -81,6 +81,7 @@
 #include <string.h>
 #include "mid.h"
 #include "mididata.h"
+#include "load_helper.h"
 
 /*#define TESTING*/
 #ifdef TESTING
@@ -300,7 +301,7 @@ bool CmidPlayer::load(const std::string &filename, const CFileProvider &fp)
     uint32_t size;
 
     f->readString((char *)s, 6);
-    size = *(uint32_t *)s; // size of FILE_OLDLUCAS
+    size = u32_unaligned(s); // size of FILE_OLDLUCAS
     good=0;
     subsongs=0;
     switch(s[0])


### PR DESCRIPTION
Hi @Malvineous 
in order to make debugging on PPC easier, I'm trying to clean up all the UBSAN warnings. It seems that the codebase does a lot of unaligned access which is undefined behaviour in C (and theoretically not even possible in C++, as you would have to break the strict aliasing rules before you even get to type pun). The recommended approach instead is to use `memcpy`, which every modern compiler can optimize to the best type of load on the target platform (on x86, GCC and Clang optimize this to a standard `mov` usually).

See also:

1. https://blog.regehr.org/archives/1520
2. https://pzemtsov.github.io/2016/11/06/bug-story-alignment-on-x86.html
3. https://blog.quarkslab.com/unaligned-accesses-in-cc-what-why-and-solutions-to-do-it-properly.html