### PR TITLE
Allow 8-bit playback

### DIFF
--- a/src/emuopl.cpp
+++ b/src/emuopl.cpp
@@ -39,6 +39,7 @@ CEmuopl::~CEmuopl()
   if(mixbufSamples) {
     delete [] mixbuf0;
     delete [] mixbuf1;
+    delete [] mixbuf2;
   }
 }
 
@@ -48,12 +49,13 @@ void CEmuopl::update(short *buf, int samples)
 
   //ensure that our mix buffers are adequately sized
   if(mixbufSamples < samples) {
-    if(mixbufSamples) { delete[] mixbuf0; delete[] mixbuf1; }
+    if(mixbufSamples) { delete[] mixbuf0; delete[] mixbuf1; delete[] mixbuf2; }
     mixbufSamples = samples;
 
     //*2 = make room for stereo, if we need it
     mixbuf0 = new short[samples*2]; 
     mixbuf1 = new short[samples*2];
+    mixbuf2 = new short[samples*2];
   }
 
   //data should be rendered to outbuf
@@ -68,9 +70,7 @@ void CEmuopl::update(short *buf, int samples)
   short *tempbuf=mixbuf0;
   short *tempbuf2=mixbuf1;
   if(use16bit) outbuf = buf;
-  else outbuf = mixbuf1;
-  //...there is a potentially confusing situation where mixbuf1 can be aliased.
-  //beware. it is a little loony.
+  else outbuf = mixbuf2;
 
   //all of the following rendering code produces 16bit output
 

--- a/src/emuopl.h
+++ b/src/emuopl.h
@@ -42,7 +42,7 @@ class CEmuopl: public Copl
  private:
   bool		use16bit, stereo;
   FM_OPL	*opl[2];				// OPL2 emulator data
-  short		*mixbuf0, *mixbuf1;
+  short		*mixbuf0, *mixbuf1, *mixbuf2;
   int		mixbufSamples;
 };
 


### PR DESCRIPTION
Currently reducing from 16-bit to 8-bit samples does not work, since 'mixbuf1' is used for both the left channel source buffer (with TYPE_DUAL_OPL2) and the stereo source destination buffer. Specifically, 'mixbuf1' array is already used by 'tempbuf2' pointer, but if 'use16bit' is false then 'mixbuf1' is also used by 'outbuf' pointer. This causes data to be overwritten when copying data from 'tempbuf2' to 'outbuf', as both are pointing to 'mixbuf1'.

To resolve this, add a new array 'mixbuf2' for 8-bit output to 'outbuf' pointer.