### PR TITLE
woodyopl: Moved generator_add

### DIFF
--- a/src/woodyopl.cpp
+++ b/src/woodyopl.cpp
@@ -33,6 +33,7 @@
 #include <string.h> // memset
 #include "woodyopl.h"
 
+static Bit32u generator_add;	// should be a chip parameter
 
 static fltype recipsamp;	// inverse of sampling rate
 static Bit16s wavtable[WAVEPREC*3];	// wave form table

--- a/src/woodyopl.h
+++ b/src/woodyopl.h
@@ -210,6 +210,4 @@ public:
 	void adlib_write_index(Bitu port, Bit8u val);
 };
 
-static Bit32u generator_add;	// should be a chip parameter
-
 #endif


### PR DESCRIPTION
Moved generator_add from the woodyopl header to the source file as it's
not used outside of the source file and having it in the header results
in compiler warnings.