### PR TITLE
Fix issues #85 to #102

### DIFF
--- a/src/a2m.h
+++ b/src/a2m.h
@@ -38,13 +38,13 @@ public:
   std::string gettype()
     { return std::string("AdLib Tracker 2"); }
   std::string gettitle()
-    { if(*songname) return std::string(songname,1,*songname); else return std::string(); }
+    { return std::string(songname + 1, *songname); }
   std::string getauthor()
-    { if(*author) return std::string(author,1,*author); else return std::string(); }
+    { return std::string(author + 1, *author); }
   unsigned int getinstruments()
     { return 250; }
   std::string getinstrument(unsigned int n)
-    { return std::string(instname[n],1,*instname[n]); }
+    { return std::string(instname[n] + 1, *instname[n]); }
 
 private:
 

--- a/src/adlib.cpp
+++ b/src/adlib.cpp
@@ -653,32 +653,14 @@ void CadlibDriver::SetFNum(uint16_t * fNumVec, int num, int den)
 */
 void CadlibDriver::ChangePitch(int voice, int pitchBend)
 {
-	int l, t1, t2, delta;
-	static int oldL = -1;
-	static int oldHt;
-	static uint16_t * oldPtr;
+	int t = (pitchBend - MID_PITCH) * pitchRangeStep / MID_PITCH;
+	int delta = t < 0 ? NR_STEP_PITCH - 1 : 0;
+	t -= delta;
 
-	l = (int)(pitchBend - MID_PITCH) * pitchRangeStep;
-	if (oldL == l) {	/* optimisation ... */
-		fNumFreqPtr[voice] = oldPtr;
-		halfToneOffset[voice] = oldHt;
-	}
-	else {
-		t1 = l / MID_PITCH;
-		if (t1 < 0) {
-			t2 = NR_STEP_PITCH - 1 - t1;
-			oldHt = halfToneOffset[voice] = -(t2 / NR_STEP_PITCH);
-			delta = (t2 - NR_STEP_PITCH + 1) % NR_STEP_PITCH;
-			if (delta)
-				delta = NR_STEP_PITCH - delta;
-		}
-		else {
-			oldHt = halfToneOffset[voice] = t1 / NR_STEP_PITCH;
-			delta = t1 % NR_STEP_PITCH;
-		}
-		oldPtr = fNumFreqPtr[voice] = (uint16_t *)fNumNotes[delta];
-		oldL = l;
-	}
+	halfToneOffset[voice] = t / NR_STEP_PITCH;
+	delta                += t % NR_STEP_PITCH;
+
+	fNumFreqPtr[voice] = fNumNotes[delta];
 }
 
 /*

--- a/src/bmf.h
+++ b/src/bmf.h
@@ -88,5 +88,6 @@ private:
   static const unsigned short bmf_notes_2[12];
   static const unsigned char bmf_default_instrument[13];
 
-  int             __bmf_convert_stream(unsigned char *stream, int channel);
+  long int        __bmf_convert_stream(const unsigned char *stream, int channel,
+                                       unsigned long stream_size);
 };

--- a/src/cmf.cpp
+++ b/src/cmf.cpp
@@ -209,6 +209,10 @@ bool CcmfPlayer::load(const std::string &filename, const CFileProvider &fp)
 	// Load the MIDI data into memory
   f->seek(this->cmfHeader.iMusicOffset);
   this->iSongLen = fp.filesize(f) - this->cmfHeader.iMusicOffset;
+  if (this->iSongLen <= 0) { // invalid offset value
+    fp.close(f);
+    return false;
+  }
   this->data = new unsigned char[this->iSongLen];
   f->readString((char *)data, this->iSongLen);
 

--- a/src/cmf.cpp
+++ b/src/cmf.cpp
@@ -229,7 +229,7 @@ bool CcmfPlayer::update()
 
 	// Read in the next event
 	while (!this->iDelayRemaining) {
-		uint8_t iCommand = this->data[this->iPlayPointer++];
+		uint8_t iCommand = this->iPlayPointer < this->iSongLen ? this->data[this->iPlayPointer++] : 0;
 		if ((iCommand & 0x80) == 0) {
 			// Running status, use previous command
 			this->iPlayPointer--;
@@ -240,12 +240,14 @@ bool CcmfPlayer::update()
 		uint8_t iChannel = iCommand & 0x0F;
 		switch (iCommand & 0xF0) {
 			case 0x80: { // Note off (two data bytes)
+				if (this->iPlayPointer < this->iSongLen - 1) break;
 				uint8_t iNote = this->data[this->iPlayPointer++];
 				uint8_t iVelocity = this->data[this->iPlayPointer++]; // release velocity
 				this->cmfNoteOff(iChannel, iNote, iVelocity);
 				break;
 			}
 			case 0x90: { // Note on (two data bytes)
+				if (this->iPlayPointer > this->iSongLen - 2) break;
 				uint8_t iNote = this->data[this->iPlayPointer++];
 				uint8_t iVelocity = this->data[this->iPlayPointer++]; // attack velocity
 				if (iVelocity) {
@@ -276,29 +278,34 @@ bool CcmfPlayer::update()
 				break;
 			}
 			case 0xA0: { // Polyphonic key pressure (two data bytes)
+				if (this->iPlayPointer > this->iSongLen - 2) break;
 				uint8_t iNote = this->data[this->iPlayPointer++];
 				uint8_t iPressure = this->data[this->iPlayPointer++];
 				AdPlug_LogWrite("CMF: Key pressure not yet implemented! (wanted ch%d/note %d set to %d)\n", iChannel, iNote, iPressure);
 				break;
 			}
 			case 0xB0: { // Controller (two data bytes)
+				if (this->iPlayPointer > this->iSongLen - 2) break;
 				uint8_t iController = this->data[this->iPlayPointer++];
 				uint8_t iValue = this->data[this->iPlayPointer++];
 				this->MIDIcontroller(iChannel, iController, iValue);
 				break;
 			}
 			case 0xC0: { // Instrument change (one data byte)
+				if (this->iPlayPointer >= this->iSongLen) break;
 				uint8_t iNewInstrument = this->data[this->iPlayPointer++];
 				this->chMIDI[iChannel].iPatch = iNewInstrument;
 				AdPlug_LogWrite("CMF: Remembering MIDI channel %d now uses patch %d\n", iChannel, iNewInstrument);
 				break;
 			}
 			case 0xD0: { // Channel pressure (one data byte)
+				if (this->iPlayPointer >= this->iSongLen) break;
 				uint8_t iPressure = this->data[this->iPlayPointer++];
 				AdPlug_LogWrite("CMF: Channel pressure not yet implemented! (wanted ch%d set to %d)\n", iChannel, iPressure);
 				break;
 			}
 			case 0xE0: { // Pitch bend (two data bytes)
+				if (this->iPlayPointer > this->iSongLen - 2) break;
 				uint8_t iLSB = this->data[this->iPlayPointer++];
 				uint8_t iMSB = this->data[this->iPlayPointer++];
 				uint16_t iValue = (iMSB << 7) | iLSB;
@@ -311,26 +318,31 @@ bool CcmfPlayer::update()
 			case 0xF0: // System message (arbitrary data bytes)
 				switch (iCommand) {
 					case 0xF0: { // Sysex
-						uint8_t iNextByte;
+						uint8_t iNextByte = 0;
 						AdPlug_LogWrite("Sysex message: ");
-						do {
+						 while ((iNextByte & 0x80) == 0 && this->iPlayPointer < this->iSongLen) {
 							iNextByte = this->data[this->iPlayPointer++];
 							AdPlug_LogWrite("%02X", iNextByte);
-						} while ((iNextByte & 0x80) == 0);
+						}
 						AdPlug_LogWrite("\n");
 						// This will have read in the terminating EOX (0xF7) message too
 						break;
 					}
 					case 0xF1: // MIDI Time Code Quarter Frame
-						this->data[this->iPlayPointer++]; // message data (ignored)
+						if (this->iPlayPointer < this->iSongLen)
+							(void)this->data[this->iPlayPointer++]; // message data (ignored)
 						break;
 					case 0xF2: // Song position pointer
-						this->data[this->iPlayPointer++]; // message data (ignored)
-						this->data[this->iPlayPointer++];
+						if (this->iPlayPointer < this->iSongLen - 1) {
+							(void)this->data[this->iPlayPointer++]; // message data (ignored)
+							(void)this->data[this->iPlayPointer++];
+						}
 						break;
 					case 0xF3: // Song select
-						this->data[this->iPlayPointer++]; // message data (ignored)
-						AdPlug_LogWrite("CMF: MIDI Song Select is not implemented.\n");
+						if (this->iPlayPointer < this->iSongLen - 1) {
+							(void)this->data[this->iPlayPointer++]; // message data (ignored)
+							AdPlug_LogWrite("CMF: MIDI Song Select is not implemented.\n");
+						}
 						break;
 					case 0xF6: // Tune request
 						break;
@@ -352,6 +364,7 @@ bool CcmfPlayer::update()
 						this->iPlayPointer = 0; // for repeat in endless-play mode
 						break;
 					case 0xFF: { // System reset, used as meta-events in a MIDI file
+						if (this->iPlayPointer >= this->iSongLen) break;
 						uint8_t iEvent = this->data[this->iPlayPointer++];
 						switch (iEvent) {
 							case 0x2F: // end of track
@@ -493,7 +506,7 @@ uint32_t CcmfPlayer::readMIDINumber()
 {
 	uint32_t iValue = 0;
 	for (int i = 0; i < 4; i++) {
-		uint8_t iNext = this->data[this->iPlayPointer++];
+		uint8_t iNext = this->iPlayPointer < this->iSongLen ? this->data[this->iPlayPointer++] : 0;
 		iValue <<= 7;
 		iValue |= (iNext & 0x7F); // ignore the MSB
 		if ((iNext & 0x80) == 0) break; // last byte has the MSB unset

--- a/src/d00.cpp
+++ b/src/d00.cpp
@@ -68,7 +68,8 @@ bool Cd00Player::load(const std::string &filename, const CFileProvider &fp)
 
   // Check for version 2-4 header
   if(strncmp(checkhead->id,"JCH\x26\x02\x66",6) || checkhead->type ||
-     !checkhead->subsongs || checkhead->soundcard) {
+     !checkhead->subsongs || checkhead->soundcard ||
+     checkhead->version < 2 || checkhead->version > 4) {
     // Check for version 0 or 1 header (and .d00 file extension)
     delete checkhead;
     if(!fp.extension(filename, ".d00")) { fp.close(f); return false; }

--- a/src/d00.h
+++ b/src/d00.h
@@ -97,6 +97,7 @@ class Cd00Player: public CPlayer
   d00header *header;
   d00header1 *header1;
   char *filedata;
+  unsigned long filesize;
 
  private:
   void setvolume(unsigned char chan);

--- a/src/dfm.cpp
+++ b/src/dfm.cpp
@@ -47,9 +47,16 @@ bool CdfmLoader::load(const std::string &filename, const CFileProvider &fp)
   restartpos = 0; flags = Standard; bpm = 0;
   init_trackord();
   f->readString(songinfo, 33);
+  if (*songinfo > 32 || *songinfo < 0) {
+    fp.close(f); return false;
+  }
   initspeed = f->readInt(1);
-  for(i = 0; i < 32; i++)
+  for(i = 0; i < 32; i++) {
     f->readString(instname[i], 12);
+    if (*instname[i] > 11 || *instname[i] < 0) {
+      fp.close(f); return false;
+    }
+  }
   for(i = 0; i < 32; i++) {
     inst[i].data[1] = f->readInt(1);
     inst[i].data[2] = f->readInt(1);

--- a/src/dfm.cpp
+++ b/src/dfm.cpp
@@ -68,8 +68,14 @@ bool CdfmLoader::load(const std::string &filename, const CFileProvider &fp)
     ;
   length = i;
   npats = f->readInt(1);
+  if (npats > 64) {
+    fp.close(f); return false;	// or: realloc_patterns(npats, 64, 9);
+  }
   for(i = 0; i < npats; i++) {
     n = f->readInt(1);
+    if (n >= npats) {
+      fp.close(f); return false;
+    }
     for(r = 0; r < 64; r++)
       for(c = 0; c < 9; c++) {
 	note = f->readInt(1);

--- a/src/dfm.h
+++ b/src/dfm.h
@@ -37,9 +37,9 @@ public:
 	unsigned int getinstruments()
 	{ return 32; };
 	std::string getinstrument(unsigned int n)
-	{ if(*instname[n]) return std::string(instname[n],1,*instname[n]); else return std::string(); };
+	{ if (n < 32 && *instname[n]) return std::string(instname[n] + 1, *instname[n]); else return std::string(); };
 	std::string getdesc()
-	{ return std::string(songinfo,1,*songinfo); };
+	{ return std::string(songinfo + 1, *songinfo); };
 
 private:
 	struct {

--- a/src/dmo.cpp
+++ b/src/dmo.cpp
@@ -243,8 +243,8 @@ unsigned short CdmoLoader::dmo_unpacker::brand(unsigned short range)
   ax = LOWORD(bseed);
   bx = HIWORD(bseed);
   cx = ax;
-  ax = LOWORD(cx * 0x8405);
-  dx = HIWORD(cx * 0x8405);
+  ax = LOWORD(cx * 0x8405U);
+  dx = HIWORD(cx * 0x8405U);
   cx <<= 3;
   cx = (((HIBYTE(cx) + LOBYTE(cx)) & 0xFF) << 8) + LOBYTE(cx);
   dx += cx;

--- a/src/dro.cpp
+++ b/src/dro.cpp
@@ -73,7 +73,7 @@ bool CdroPlayer::load(const std::string &filename, const CFileProvider &fp)
 
 	f->ignore(4);	// Length in milliseconds
 	this->iLength = f->readInt(4); // stored in file as number of bytes
-	if (this->iLength < 3) {
+	if (this->iLength < 3 || this->iLength > fp.filesize(f) - f->pos()) {
 		fp.close(f);
 		return false;
 	}

--- a/src/dro2.cpp
+++ b/src/dro2.cpp
@@ -64,7 +64,13 @@ bool Cdro2Player::load(const std::string &filename, const CFileProvider &fp)
 		return false;
 	}
 
-	this->iLength = f->readInt(4) * 2; // stored in file as number of byte pairs
+	this->iLength = f->readInt(4); // should better use an unsigned type
+	if (this->iLength <= 0 || this->iLength >= 1<<30 ||
+	    this->iLength > fp.filesize(f) - f->pos()) {
+		fp.close(f);
+		return false;
+	}
+	this->iLength *= 2; // stored in file as number of byte p
 	f->ignore(4);	// Length in milliseconds
 	f->ignore(1);	/// OPL type (0 == OPL2, 1 == Dual OPL2, 2 == OPL3)
 	int iFormat = f->readInt(1);

--- a/src/dro2.cpp
+++ b/src/dro2.cpp
@@ -163,7 +163,7 @@ bool Cdro2Player::update()
 			} else {
 			  this->opl->setchip(0);
 			}
-			if (iIndex > this->iConvTableLen) {
+			if (iIndex >= this->iConvTableLen) {
 				printf("DRO2: Error - index beyond end of codemap table!  Corrupted .dro?\n");
 				return false; // EOF
 			}

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -193,8 +193,10 @@ void CxadhybridPlayer::xadplayer_update()
 			// is slide ?
 			if (slide)
 			{
-				hyb.channel[i].freq_slide = (((slide >> 3) * -1) * (slide & 7)) << 1;
-    
+				// Looks bogus. Should values 0..8 really result
+				// in 0 or is bit 3 supposed to be a sign?
+				hyb.channel[i].freq_slide = -(slide >> 3) * (slide & 7) * 2;
+				// And this statement is dead anyway.
 				if (slide & 0x80) slide = -(slide & 7);
 			}
 

--- a/src/imf.cpp
+++ b/src/imf.cpp
@@ -89,6 +89,10 @@ bool CimfPlayer::load(const std::string &filename, const CFileProvider &fp)
   else
     fsize = f->readInt(2);
   flsize = fp.filesize(f);
+  if (mfsize + 4 > flsize || fsize >= flsize - 2 - mfsize || fsize & 3) {
+    fp.close(f);        // truncated file or bad size record
+    return false;
+  }    
   if(!fsize) {		// footerless file (raw music data)
     if(mfsize)
       f->seek(-4, binio::Add);

--- a/src/jbm.h
+++ b/src/jbm.h
@@ -29,10 +29,10 @@ class CjbmPlayer: public CPlayer
  public:
   static CPlayer *factory(Copl *newopl);
 
-  CjbmPlayer(Copl *newopl) : CPlayer(newopl), m(0)
+  CjbmPlayer(Copl *newopl) : CPlayer(newopl), m(0), sequences(0)
     { }
   ~CjbmPlayer()
-    { if(m != NULL) delete [] m; }
+    { delete[] sequences; delete[] m; }
 
   bool load(const std::string &filename, const CFileProvider &fp);
   bool update();

--- a/src/mdi.h
+++ b/src/mdi.h
@@ -73,7 +73,7 @@ public:
 	~CmdiPlayer()
 	{
 		if(data) delete [] data;
-		if (drv) drv->~CadlibDriver();
+		if (drv) delete drv;
 	};
 
 	bool load(const std::string &filename, const CFileProvider &fp);

--- a/src/mtk.cpp
+++ b/src/mtk.cpp
@@ -39,6 +39,8 @@ bool CmtkLoader::load(const std::string &filename, const CFileProvider &fp)
   struct mtkdata {
     char songname[34],composername[34],instname[0x80][34];
     unsigned char insts[0x80][12],order[0x80],dummy,patterns[0x32][0x40][9];
+    // HSC pattern has different type and size from patterns, but that
+    // doesn't matter much since we memcpy() the data. Still confusing.
   } *data;
   unsigned char *cmp,*org;
   unsigned int i;
@@ -51,8 +53,10 @@ bool CmtkLoader::load(const std::string &filename, const CFileProvider &fp)
   header.size = f->readInt(2);
 
   // file validation section
-  if(strncmp(header.id,"mpu401tr\x92kk\xeer@data",18))
-    { fp.close(f); return false; }
+  if (memcmp(header.id, "mpu401tr\x92kk\xeer@data", 18) ||
+      header.size < sizeof(*data) - sizeof(data->patterns)) {
+    fp.close(f); return false;
+  }
 
   // load section
   cmpsize = fp.filesize(f) - 22;
@@ -64,6 +68,7 @@ bool CmtkLoader::load(const std::string &filename, const CFileProvider &fp)
   while(cmpptr < cmpsize) {	// decompress
     ctrlmask >>= 1;
     if(!ctrlmask) {
+      if (cmpptr + 2 > cmpsize) goto err;
       ctrlbits = cmp[cmpptr] + (cmp[cmpptr + 1] << 8);
       cmpptr += 2;
       ctrlmask = 0x8000;
@@ -81,37 +86,40 @@ bool CmtkLoader::load(const std::string &filename, const CFileProvider &fp)
     cmd = (cmp[cmpptr] >> 4) & 0x0f;
     cnt = cmp[cmpptr] & 0x0f;
     cmpptr++;
+    if (cmpptr >= cmpsize) goto err;
     switch(cmd) {
     case 0:
-      if(orgptr + cnt > header.size) goto err;
       cnt += 3;
+      if (orgptr + cnt > header.size) goto err;
       memset(&org[orgptr],cmp[cmpptr],cnt);
       cmpptr++; orgptr += cnt;
       break;
 
     case 1:
-      if(orgptr + cnt > header.size) goto err;
       cnt += (cmp[cmpptr] << 4) + 19;
+      if (orgptr + cnt > header.size || cmpptr >= cmpsize) goto err;
       memset(&org[orgptr],cmp[++cmpptr],cnt);
       cmpptr++; orgptr += cnt;
       break;
 
     case 2:
-      if(orgptr + cnt > header.size) goto err;
+      if (cmpptr + 2 > cmpsize) goto err;
       offs = (cnt+3) + (cmp[cmpptr] << 4);
       cnt = cmp[++cmpptr] + 16; cmpptr++;
+      if (orgptr + cnt > header.size || offs > orgptr) goto err;
       memcpy(&org[orgptr],&org[orgptr - offs],cnt);
       orgptr += cnt;
       break;
 
     default:
-      if(orgptr + cmd > header.size) goto err;
       offs = (cnt+3) + (cmp[cmpptr++] << 4);
+      if (orgptr + cmd > header.size || offs > orgptr) goto err;
       memcpy(&org[orgptr],&org[orgptr-offs],cmd);
       orgptr += cmd;
       break;
     }
   }
+  // orgptr should match header.size; add a check?
   delete [] cmp;
   data = (struct mtkdata *) org;
 
@@ -123,12 +131,14 @@ bool CmtkLoader::load(const std::string &filename, const CFileProvider &fp)
     strncpy(instname[i],data->instname[i]+1,33);
   memcpy(instr,data->insts,0x80 * 12);
   memcpy(song,data->order,0x80);
-  memcpy(patterns,data->patterns,header.size-6084);
   for (i=0;i<128;i++) {				// correct instruments
     instr[i][2] ^= (instr[i][2] & 0x40) << 1;
     instr[i][3] ^= (instr[i][3] & 0x40) << 1;
     instr[i][11] >>= 4;		// make unsigned
   }
+  cnt = header.size - (sizeof(*data) - sizeof(data->patterns)); // was off by 1
+  if (cnt > sizeof(patterns)) cnt = sizeof(patterns); // fail?
+  memcpy(patterns, data->patterns, cnt);
 
   delete [] org;
   rewind(0);

--- a/src/mtk.h
+++ b/src/mtk.h
@@ -43,7 +43,7 @@ class CmtkLoader: public ChscPlayer
   unsigned int getinstruments()
     { return 128; };
   std::string getinstrument(unsigned int n)
-    { return std::string(instname[n]); };
+    { return n < 128 ? std::string(instname[n]) : std::string(); };
 
  private:
   char title[34],composer[34],instname[0x80][34];

--- a/src/mus.h
+++ b/src/mus.h
@@ -79,7 +79,7 @@ public:
 	{
 		if (data) delete [] data;
 		if (insts) delete[] insts;
-		if (drv) drv->~CadlibDriver();
+		if (drv) delete drv;
 	};
 
 	bool load(const std::string &filename, const CFileProvider &fp);

--- a/src/opl.h
+++ b/src/opl.h
@@ -41,7 +41,7 @@ class Copl
   virtual void write(int reg, int val) = 0;	// combined register select + data write
   virtual void setchip(int n)			// select OPL chip
     {
-      if(n < 2)
+      if(n >= 0 && n < 2)
 	currChip = n;
     }
 

--- a/src/raw.cpp
+++ b/src/raw.cpp
@@ -135,6 +135,7 @@ bool CrawPlayer::update()
 
   do {
     setspeed = false;
+    if (this->pos >= this->length) return false;
 
     switch(this->data[this->pos].command) {
     case 0:
@@ -144,6 +145,7 @@ bool CrawPlayer::update()
     case 2:
       if (!this->data[this->pos].param) {
         pos++;
+        if (this->pos >= this->length) return false;
         this->speed = this->data[this->pos].param + (this->data[this->pos].command << 8);
         setspeed = true;
       } else

--- a/src/raw.cpp
+++ b/src/raw.cpp
@@ -51,7 +51,9 @@ bool CrawPlayer::load(const std::string &filename, const CFileProvider &fp)
 
   // load section
   this->clock = f->readInt(2); // clock speed
-  this->length = (fp.filesize(f) - 10) / 2; // Wraithverge: total data-size.
+  this->length = fp.filesize(f);
+  if (this->length <= 10) { fp.close (f); return false; }
+  this->length = (this->length - 10) / 2; // Wraithverge: total data-size.
   this->data = new Tdata [this->length];
   bool tagdata = false;
   title[0] = 0;

--- a/src/rix.cpp
+++ b/src/rix.cpp
@@ -25,17 +25,9 @@
 #include "rix.h"
 #include "debug.h"
 
-#if defined(__hppa__) || \
-   defined(__m68k__) || defined(mc68000) || defined(_M_M68K) || \
-   (defined(__MIPS__) && defined(__MISPEB__)) || \
-   defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC) || \
-   defined(__sparc__)
-   // big endian
-   #define RIX_SWAP32(a) (((a) << 24) | (((a) << 8) & 0x00FF0000) | (((a) >> 8) & 0x0000FF00) | ((a) >> 24))
-#else
-   // little endian
-   #define RIX_SWAP32(a) (a)
-#endif
+#define RIX_GET32(p, i) \
+  ((uint32_t)p[4*i] | (uint32_t)p[4*i+1] << 8 | \
+   (uint32_t)p[4*i+2] << 16 | (uint32_t)p[4*i + 3] << 24)
 
 const uint8_t CrixPlayer::adflag[] = {0,0,0,1,1,1,0,0,0,1,1,1,0,0,0,1,1,1};
 const uint8_t CrixPlayer::reg_data[] = {0,1,2,3,4,5,8,9,10,11,12,13,16,17,18,19,20,21};
@@ -80,9 +72,8 @@ CrixPlayer::~CrixPlayer()
 bool CrixPlayer::load(const std::string &filename, const CFileProvider &fp)
 {
   binistream *f = fp.open(filename); if(!f) return false;
-  uint32_t i=0;
 
-  if(stricmp(filename.substr(filename.length()-4,4).c_str(),".mkf")==0)
+  if (fp.extension(filename, ".mkf"))
   {
 	  flag_mkf=1;
 	  f->seek(0);
@@ -90,11 +81,10 @@ bool CrixPlayer::load(const std::string &filename, const CFileProvider &fp)
 	  f->seek(offset);
   }
   if(f->readInt(2)!=0x55aa){ fp.close(f);return false; }
-  file_buffer = new uint8_t [fp.filesize(f) + 1];
+  length = pos = fp.filesize(f);
+  file_buffer = new uint8_t[length];
   f->seek(0);
-  while(!f->eof())
-	file_buffer[i++]=f->readInt(1);
-  length=i;
+  f->readString((char *)file_buffer, length);
   fp.close(f);
   if(!flag_mkf)
 	  rix_buf=file_buffer;
@@ -122,7 +112,7 @@ void CrixPlayer::rewind(int subsong)
   bd_modify = 0;
   sustain = 0;
   play_end = 0;
-  pos = index = 0; 
+  index = 0; 
 
   memset(f_buffer,   0,     sizeof(f_buffer));
   memset(a0b0_data2, 0,     sizeof(a0b0_data2));
@@ -133,15 +123,29 @@ void CrixPlayer::rewind(int subsong)
   memset(insbuf,     0,     sizeof(insbuf));
   memset(displace,   0,     sizeof(displace));
   memset(reg_bufs,   0,     sizeof(reg_bufs));
-  memset(for40reg,   0x7F,  sizeof(for40reg));
+  memset(for40reg,   0x7F,  sizeof(for40reg)); // FIXME: !static
 
-  if(flag_mkf)
+  if (flag_mkf && subsong >= 0)
   {
-	  uint32_t *buf_index=(uint32_t *)file_buffer;
-	  int offset1=RIX_SWAP32(buf_index[subsong]),offset2;
-	  while((offset2=RIX_SWAP32(buf_index[++subsong]))==offset1);
-	  length=offset2-offset1+1;
-	  rix_buf=file_buffer+offset1;
+    // changed to actually work and match numbering of getsubsongs()
+    uint32_t i, offset, next, table_end;
+    offset = RIX_GET32(file_buffer, 0);
+    table_end = offset / 4;
+    for (i = 1; i < table_end; i++)
+      {
+        next = RIX_GET32(file_buffer, i);
+        if (next != offset)
+          {
+            if (--subsong < 0) break;
+            offset = next;
+          }
+      }
+    // fix up bad/unknown offsets to end of file_buffer
+    if (offset > pos) offset = pos;
+    if (i >= table_end || next > pos || next < offset) next = pos;
+    // start and length of the subsong
+    rix_buf = file_buffer + offset;
+    length = next - offset;
   }
   opl->init();
   opl->write(1,32);	// go to OPL2 mode
@@ -153,10 +157,10 @@ uint32_t CrixPlayer::getsubsongs()
 {
 	if(flag_mkf)
 	{
-		uint32_t *buf_index=(uint32_t *)file_buffer;
-		int songs=RIX_SWAP32(buf_index[0])/4,i=0;
-		for(i=0;i<songs;i++)
-			if(buf_index[i+1]==buf_index[i])
+		uint32_t songs = RIX_GET32(file_buffer, 0) / 4;
+		for (uint32_t i = songs-1; i > 0; i--)
+			if (RIX_GET32(file_buffer, i) ==
+			    RIX_GET32(file_buffer, i-1))
 				songs--;
 		return songs;
 	}
@@ -192,10 +196,14 @@ inline void CrixPlayer::ad_a0b0l_reg_(uint16_t index,uint16_t p2,uint16_t p3)
 }
 inline void CrixPlayer::data_initial()
 {
-  rhythm = rix_buf[2];
-  mus_block = (rix_buf[0x0D]<<8)+rix_buf[0x0C];
-  ins_block = (rix_buf[0x09]<<8)+rix_buf[0x08];
-  I = mus_block+1;
+  if (0x0D < length)
+    {
+      rhythm = rix_buf[2];
+      mus_block = (rix_buf[0x0D] << 8) + rix_buf[0x0C];
+      ins_block = (rix_buf[0x09] << 8) + rix_buf[0x08];
+      I = mus_block + 1;
+    }
+  else I = mus_block = length; // file too short; will stop playing immediately
   if(rhythm != 0)
     {
       //		ad_a0b0_reg(6);
@@ -273,7 +281,7 @@ inline uint16_t CrixPlayer::rix_proc()
   uint8_t ctrl = 0;
   if(music_on == 0||pause_flag == 1) return 0;
   band = 0;
-  while(rix_buf[I] != 0x80 && I<length-1)
+  while (I < length && rix_buf[I] != 0x80)
     {
       band_low = rix_buf[I-1];
       ctrl = rix_buf[I]; I+=2;
@@ -297,6 +305,8 @@ inline uint16_t CrixPlayer::rix_proc()
 /*--------------------------------------------------------------*/
 inline void CrixPlayer::rix_get_ins()
 {
+  if (ins_block + (band_low << 6) + sizeof(insbuf) >= length) return;
+
   int		i;
   uint8_t	*baddr = (&rix_buf[ins_block])+(band_low<<6);
 
@@ -306,6 +316,7 @@ inline void CrixPlayer::rix_get_ins()
 /*--------------------------------------------------------------*/
 inline void CrixPlayer::rix_90_pro(uint16_t ctrl_l)
 {
+  if (ctrl_l >= 11) return; // modify[] has size 28
   if(rhythm == 0 || ctrl_l < 6)
     {
       ins_to_reg(modify[ctrl_l*2],insbuf,insbuf[26]);
@@ -317,7 +328,7 @@ inline void CrixPlayer::rix_90_pro(uint16_t ctrl_l)
 		  ins_to_reg(modify[ctrl_l*2+6],insbuf,insbuf[26]);
 		  return;
 		}
-  else
+  else // same effect as 1st case, no need to handle separately
 		{
 		  ins_to_reg(12,insbuf,insbuf[26]);
 		  ins_to_reg(15,insbuf+13,insbuf[27]);
@@ -337,9 +348,10 @@ inline void CrixPlayer::rix_A0_pro(uint16_t ctrl_l,uint16_t index)
 /*--------------------------------------------------------------*/
 inline void CrixPlayer::prepare_a0b0(uint16_t index,uint16_t v)  /* important !*/
 {
+  if (index >= 11) return;
   short high = 0,low = 0; uint32_t res;
   int res1 = (v-0x2000)*0x19;
-  if(res1 == (int)0xff) return;
+  if(res1 == (int)0xff) return; // impossible
   low = res1/0x2000;
   if(low < 0)
     {
@@ -367,12 +379,13 @@ inline void CrixPlayer::prepare_a0b0(uint16_t index,uint16_t v)  /* important !*
 /*--------------------------------------------------------------*/
 inline void CrixPlayer::ad_a0b0l_reg(uint16_t index,uint16_t p2,uint16_t p3)
 {
+  if (index >= 11) return;
   uint16_t data; uint16_t i = p2+a0b0_data2[index];
   a0b0_data4[index] = p3;
   a0b0_data3[index] = p2;
   i = ((signed short)i<=0x5F?i:0x5F);
   i = ((signed short)i>=0?i:0);
-  data = f_buffer[addrs_head[i]+displace[index]/2];
+  data = f_buffer[addrs_head[i]+displace[index]/2]; // sum <= 11+24*24/2 < 300
   ad_bop(0xA0+index,data);
   data = a0b0_data5[i]*4+(p3<1?0:0x20)+((data>>8)&3);
   ad_bop(0xB0+index,data);
@@ -380,6 +393,7 @@ inline void CrixPlayer::ad_a0b0l_reg(uint16_t index,uint16_t p2,uint16_t p3)
 /*--------------------------------------------------------------*/
 inline void CrixPlayer::rix_B0_pro(uint16_t ctrl_l,uint16_t index)
 {
+  if (ctrl_l >= 11) return;
   register int temp = 0;
   if(rhythm == 0 || ctrl_l < 6) temp = modify[ctrl_l*2+1];
   else

--- a/src/rol.cpp
+++ b/src/rol.cpp
@@ -615,11 +615,11 @@ void CrolPlayer::send_operator(int const voice, SOPL2Op const & modulator,  SOPL
 //---------------------------------------------------------
 void CrolPlayer::load_tempo_events(binistream *f)
 {
-    int16_t const num_tempo_events = static_cast<uint16_t>(f->readInt(2));
+    uint16_t const num_tempo_events = static_cast<uint16_t>(f->readInt(2));
 
     mTempoEvents.reserve(num_tempo_events);
 
-    for (int i=0; i<num_tempo_events; ++i)
+    for (uint16_t i=0; i<num_tempo_events; ++i)
     {
         STempoEvent event;
 
@@ -684,7 +684,7 @@ void CrolPlayer::load_note_events(binistream *f, CVoiceData & voice)
             note_events.push_back(event);
 
             total_duration += event.duration;
-        } while (total_duration < time_of_last_note);
+        } while (total_duration < time_of_last_note && !f->error());
 
         if (time_of_last_note > mTimeOfLastNote)
         {
@@ -698,17 +698,18 @@ void CrolPlayer::load_note_events(binistream *f, CVoiceData & voice)
 void CrolPlayer::load_instrument_events(binistream *f, CVoiceData & voice,
                                         binistream *bnk_file, SBnkHeader const & bnk_header)
 {
-    int16_t const number_of_instrument_events = static_cast<int16_t>(f->readInt(2));
+    uint16_t const number_of_instrument_events = static_cast<uint16_t>(f->readInt(2));
 
     TInstrumentEvents & instrument_events = voice.instrument_events;
 
     instrument_events.reserve(number_of_instrument_events);
 
-    for (int16_t i = 0; i < number_of_instrument_events; ++i)
+    for (uint16_t i = 0; i < number_of_instrument_events; ++i)
     {
         SInstrumentEvent event;
         event.time = static_cast<int16_t>(f->readInt(2));
         f->readString(event.name, ROL_MAX_NAME_SIZE);
+        event.name[ROL_MAX_NAME_SIZE - 1] = 0;
 
         std::string event_name = event.name;
         if (std::find(usedInstruments.begin(), usedInstruments.end(), event_name) == usedInstruments.end())
@@ -725,13 +726,13 @@ void CrolPlayer::load_instrument_events(binistream *f, CVoiceData & voice,
 //---------------------------------------------------------
 void CrolPlayer::load_volume_events(binistream *f, CVoiceData & voice)
 {
-    int16_t const number_of_volume_events = static_cast<int16_t>(f->readInt(2));
+    uint16_t const number_of_volume_events = static_cast<uint16_t>(f->readInt(2));
 
     TVolumeEvents & volume_events = voice.volume_events;
 
     volume_events.reserve(number_of_volume_events);
 
-    for (int i=0; i<number_of_volume_events; ++i)
+    for (uint16_t i=0; i<number_of_volume_events; ++i)
     {
         SVolumeEvent event;
         event.time       = static_cast<int16_t>(f->readInt(2));
@@ -745,13 +746,13 @@ void CrolPlayer::load_volume_events(binistream *f, CVoiceData & voice)
 //---------------------------------------------------------
 void CrolPlayer::load_pitch_events(binistream *f, CVoiceData & voice)
 {
-    int16_t const number_of_pitch_events = static_cast<int16_t>(f->readInt(2));
+    uint16_t const number_of_pitch_events = static_cast<uint16_t>(f->readInt(2));
 
     TPitchEvents & pitch_events = voice.pitch_events;
 
     pitch_events.reserve(number_of_pitch_events);
 
-    for (int i=0; i<number_of_pitch_events; ++i)
+    for (uint16_t i=0; i<number_of_pitch_events; ++i)
     {
         SPitchEvent event;
         event.time      = static_cast<int16_t>(f->readInt(2));
@@ -785,6 +786,7 @@ bool CrolPlayer::load_bnk_info(binistream *f, SBnkHeader & header)
         instrument.index = static_cast<uint16_t>(f->readInt(2));
         instrument.record_used = static_cast<uint8_t>(f->readInt(1));
         f->readString(instrument.name, ROL_MAX_NAME_SIZE);
+        instrument.name[ROL_MAX_NAME_SIZE - 1] = 0;
 
         ins_name_list.push_back( instrument );
     }
@@ -816,7 +818,7 @@ int CrolPlayer::load_rol_instrument(binistream *f, SBnkHeader const & header, st
 
     if (range.first != range.second)
     {
-        int const seekOffs = header.abs_offset_of_data + (range.first->index * kSizeofDataRecord);
+        long int const seekOffs = header.abs_offset_of_data + (range.first->index * kSizeofDataRecord);
         f->seek(seekOffs, binio::Set);
 
         read_rol_instrument(f, usedInstrument.instrument);

--- a/src/rol.h
+++ b/src/rol.h
@@ -60,7 +60,7 @@ public:
     };
     virtual std::string getinstrument(unsigned int n)
     {
-        return usedInstruments[n];
+        return n < usedInstruments.size() ? usedInstruments[n] : std::string();
     };
     virtual std::string getdesc()
     {

--- a/src/sop.h
+++ b/src/sop.h
@@ -168,7 +168,7 @@ public:
 			}
 			delete[] track;
 		}
-		if (drv) drv->~Cad262Driver();
+		if (drv) delete drv;
 	};
 
 	bool load(const std::string &filename, const CFileProvider &fp);

--- a/src/u6m.cpp
+++ b/src/u6m.cpp
@@ -66,6 +66,7 @@ bool Cu6mPlayer::load(const std::string &filename, const CFileProvider &fp)
     }
 
   // load section
+  delete[] song_data;
   song_data = new unsigned char[decompressed_filesize];
   unsigned char* compressed_song_data = new unsigned char[filesize-3];
 
@@ -74,7 +75,6 @@ bool Cu6mPlayer::load(const std::string &filename, const CFileProvider &fp)
   fp.close(f);
 
   // attempt to decompress the song data
-  // if unsuccessful, deallocate song_data[] on the spot, and return(false)
   data_block source, destination;
   source.size = filesize-4;
   source.data = compressed_song_data;
@@ -84,7 +84,6 @@ bool Cu6mPlayer::load(const std::string &filename, const CFileProvider &fp)
   if (!lzw_decompress(source,destination))
     {
       delete[] compressed_song_data;
-      delete[] song_data;
       return(false);
     }
 

--- a/src/u6m.cpp
+++ b/src/u6m.cpp
@@ -23,11 +23,7 @@
 #include "u6m.h"
 
 // Makes security checks on output buffer before writing
-#define SAVE_OUTPUT_ROOT(c, d, p) \
-if(p < d.size) \
-  output_root(c, d.data, p); \
-else \
-  return false;
+#define SAVE_OUTPUT_ROOT(c, d, p) if(!output_root(c, d, p)) return false;
 
 CPlayer *Cu6mPlayer::factory(Copl *newopl)
 {
@@ -38,7 +34,7 @@ bool Cu6mPlayer::load(const std::string &filename, const CFileProvider &fp)
 {
   // file validation section
   // this section only checks a few *necessary* conditions
-  unsigned long filesize, decompressed_filesize;
+  size_t filesize, decompressed_filesize;
   binistream *f;
 
   f = fp.open(filename); if(!f) return false;
@@ -66,7 +62,7 @@ bool Cu6mPlayer::load(const std::string &filename, const CFileProvider &fp)
     }
 
   // load section
-  delete[] song_data;
+  delete[] song_data; song_size = 0;
   song_data = new unsigned char[decompressed_filesize];
   unsigned char* compressed_song_data = new unsigned char[filesize-3];
 
@@ -90,6 +86,7 @@ bool Cu6mPlayer::load(const std::string &filename, const CFileProvider &fp)
   // deallocation section
   delete[] compressed_song_data;
 
+  song_size = decompressed_filesize;
   rewind(0);
   return (true);
 }
@@ -147,7 +144,6 @@ bool Cu6mPlayer::update()
 
 void Cu6mPlayer::rewind(int subsong)
 {
-  played_ticks = 0;
   songend = false;
 
   // set the driver's internal variables
@@ -205,13 +201,13 @@ bool Cu6mPlayer::lzw_decompress(Cu6mPlayer::data_block source, Cu6mPlayer::data_
 {
   bool end_marker_reached = false;
   int codeword_size = 9;
-  long bits_read = 0;
+  unsigned long bits_read = 0;
   int next_free_codeword = 0x102;
   int dictionary_size = 0x200;
   MyDict dictionary = MyDict();
   std::stack<unsigned char> root_stack;
 
-  long bytes_written = 0;
+  size_t bytes_written = 0;
 
   int cW;
   int pW;
@@ -315,7 +311,8 @@ bool Cu6mPlayer::lzw_decompress(Cu6mPlayer::data_block source, Cu6mPlayer::data_
 
 
 // Read the next code word from the source buffer
-int Cu6mPlayer::get_next_codeword (long& bits_read, data_block& source, int codeword_size)
+int Cu6mPlayer::get_next_codeword (unsigned long& bits_read, data_block& source,
+                                   int codeword_size)
 {
   unsigned char b0,b1,b2;
   int codeword;
@@ -356,10 +353,17 @@ int Cu6mPlayer::get_next_codeword (long& bits_read, data_block& source, int code
 
 
 // output a root to memory
-void Cu6mPlayer::output_root(unsigned char root, unsigned char *destination, long& position)
+bool Cu6mPlayer::output_root(unsigned char root, data_block& destination,
+                             size_t& position)
 {
-  destination[position] = root;
+  if (position >= destination.size)
+    {
+      return false;
+    }
+
+  destination.data[position] = root;
   position++;
+  return true;
 }
 
 
@@ -395,7 +399,7 @@ void Cu6mPlayer::get_string(int codeword, Cu6mPlayer::MyDict& dictionary, std::s
 // This function reads the song data and executes the embedded commands.
 void Cu6mPlayer::command_loop()
 {
-  unsigned char command_byte;   // current command byte
+  int command_byte;             // current command byte
   int command_nibble_hi;        // command byte, bits 4-7
   int command_nibble_lo;        // command byte, bite 0-3
   bool repeat_loop = true;      //
@@ -404,6 +408,11 @@ void Cu6mPlayer::command_loop()
     {
       // extract low and high command nibbles
       command_byte = read_song_byte();   // implicitly increments song_pos
+      if (command_byte < 0)              // handle invalid position
+        {
+          songend = true;
+          break;
+        }
       command_nibble_hi = command_byte >> 4;
       command_nibble_lo = command_byte & 0xf;
  
@@ -453,7 +462,10 @@ void Cu6mPlayer::command_0(int channel)
 
   freq_byte = read_song_byte();
   freq_word = expand_freq_byte(freq_byte);
-  set_adlib_freq(channel,freq_word);
+  if (channel < 9)
+    {
+      set_adlib_freq(channel, freq_word);
+    }
 }
 
 
@@ -464,18 +476,19 @@ void Cu6mPlayer::command_0(int channel)
 // ---------------------------------------------------
 void Cu6mPlayer::command_1(int channel)
 {
-  unsigned char freq_byte;
-  byte_pair freq_word;
+  unsigned char freq_byte = read_song_byte();
+  byte_pair freq_word = expand_freq_byte(freq_byte);
 
-  vb_direction_flag[channel] = 0;
-  vb_current_value[channel] = 0;
+  if (channel < 9)
+    {
+      vb_direction_flag[channel] = 0;
+      vb_current_value[channel] = 0;
  
-  freq_byte = read_song_byte();
-  freq_word = expand_freq_byte(freq_byte);
-  set_adlib_freq(channel,freq_word);
+      set_adlib_freq(channel, freq_word);
 
-  freq_word.hi = freq_word.hi | 0x20; // note on
-  set_adlib_freq(channel,freq_word);
+      freq_word.hi = freq_word.hi | 0x20; // note on
+      set_adlib_freq(channel, freq_word);
+    }
 }
 
 
@@ -492,7 +505,10 @@ void Cu6mPlayer::command_2(int channel)
   freq_byte = read_song_byte();
   freq_word = expand_freq_byte(freq_byte);
   freq_word.hi = freq_word.hi | 0x20; // note on
-  set_adlib_freq(channel,freq_word);
+  if (channel < 9)
+    {
+      set_adlib_freq(channel, freq_word);
+    }
 }
 
 
@@ -503,11 +519,13 @@ void Cu6mPlayer::command_2(int channel)
 // --------------------------------------
 void Cu6mPlayer::command_3(int channel)
 {
-  unsigned char mf_byte;
+  unsigned char mf_byte = read_song_byte();
 
-  carrier_mf_signed_delta[channel] = 0;
-  mf_byte = read_song_byte();
-  set_carrier_mf(channel,mf_byte);
+  if (channel < 9)
+    {
+      carrier_mf_signed_delta[channel] = 0;
+      set_carrier_mf(channel, mf_byte); // apply mask?
+    }
 }
 
 
@@ -518,10 +536,12 @@ void Cu6mPlayer::command_3(int channel)
 // ----------------------------------------
 void Cu6mPlayer::command_4(int channel)
 {
-  unsigned char mf_byte;
+  unsigned char mf_byte = read_song_byte();
 
-  mf_byte = read_song_byte();
-  set_modulator_mf(channel,mf_byte);
+  if (channel < 9)
+    {
+      set_modulator_mf(channel, mf_byte); // apply mask?
+    }
 }
 
 
@@ -532,7 +552,12 @@ void Cu6mPlayer::command_4(int channel)
 // --------------------------------------------
 void Cu6mPlayer::command_5(int channel)
 {
-  channel_freq_signed_delta[channel] = read_signed_song_byte();
+  signed char delta = read_signed_song_byte();
+
+  if (channel < 9)
+    {
+      channel_freq_signed_delta[channel] = delta;
+    }
 }
 
 
@@ -545,11 +570,13 @@ void Cu6mPlayer::command_5(int channel)
 // --------------------------------------------
 void Cu6mPlayer::command_6(int channel)
 {
-  unsigned char vb_parameters;
+  unsigned char vb_parameters = read_song_byte();
 
-  vb_parameters = read_song_byte();
-  vb_double_amplitude[channel] = vb_parameters >> 4; // high nibble
-  vb_multiplier[channel] = vb_parameters & 0xF; // low nibble
+  if (channel < 9)
+    {
+      vb_double_amplitude[channel] = vb_parameters >> 4; // high nibble
+      vb_multiplier[channel] = vb_parameters & 0xF; // low nibble
+    }
 }
 
 
@@ -560,18 +587,23 @@ void Cu6mPlayer::command_6(int channel)
 // ----------------------------------------
 void Cu6mPlayer::command_7(int channel)
 {
-  int instrument_offset = instrument_offsets[read_song_byte()];
-  out_adlib_opcell(channel, false, 0x20, *(song_data + instrument_offset+0));
-  out_adlib_opcell(channel, false, 0x40, *(song_data + instrument_offset+1));
-  out_adlib_opcell(channel, false, 0x60, *(song_data + instrument_offset+2));
-  out_adlib_opcell(channel, false, 0x80, *(song_data + instrument_offset+3));
-  out_adlib_opcell(channel, false, 0xE0, *(song_data + instrument_offset+4));
-  out_adlib_opcell(channel, true, 0x20, *(song_data + instrument_offset+5));
-  out_adlib_opcell(channel, true, 0x40, *(song_data + instrument_offset+6));
-  out_adlib_opcell(channel, true, 0x60, *(song_data + instrument_offset+7));
-  out_adlib_opcell(channel, true, 0x80, *(song_data + instrument_offset+8));
-  out_adlib_opcell(channel, true, 0xE0, *(song_data + instrument_offset+9));
-  out_adlib(0xC0+channel, *(song_data + instrument_offset+10));
+  unsigned char instrument_number = read_song_byte();
+
+  if (channel < 9 && instrument_number < 9)
+    {
+      size_t instrument_offset = instrument_offsets[instrument_number];
+      out_adlib_opcell(channel, false, 0x20, song_data[instrument_offset+0]);
+      out_adlib_opcell(channel, false, 0x40, song_data[instrument_offset+1]);
+      out_adlib_opcell(channel, false, 0x60, song_data[instrument_offset+2]);
+      out_adlib_opcell(channel, false, 0x80, song_data[instrument_offset+3]);
+      out_adlib_opcell(channel, false, 0xE0, song_data[instrument_offset+4]);
+      out_adlib_opcell(channel, true, 0x20, song_data[instrument_offset+5]);
+      out_adlib_opcell(channel, true, 0x40, song_data[instrument_offset+6]);
+      out_adlib_opcell(channel, true, 0x60, song_data[instrument_offset+7]);
+      out_adlib_opcell(channel, true, 0x80, song_data[instrument_offset+8]);
+      out_adlib_opcell(channel, true, 0xE0, song_data[instrument_offset+9]);
+      out_adlib(0xC0+channel, song_data[instrument_offset+10]);
+    }
 }
 
 
@@ -587,9 +619,12 @@ void Cu6mPlayer::command_81()
   subsong_info new_ss_info;
  
   new_ss_info.subsong_repetitions = read_song_byte();
-  new_ss_info.subsong_start = read_song_byte(); new_ss_info.subsong_start += read_song_byte() << 8;
+  new_ss_info.subsong_start = read_song_byte();
+  new_ss_info.subsong_start += read_song_byte() << 8;
   new_ss_info.continue_pos = song_pos;
 
+  // Since the new position is not validated, this could jump after the
+  // end of song_data. Handled by the usual checks.
   subsong_stack.push(new_ss_info);
   song_pos = new_ss_info.subsong_start;
 }
@@ -614,8 +649,12 @@ void Cu6mPlayer::command_82()
 void Cu6mPlayer::command_83()
 {
   unsigned char instrument_number = read_song_byte();
-  instrument_offsets[instrument_number] = song_pos;
-  song_pos += 11;
+
+  if (instrument_number < 9 && song_size > 11 && song_pos < song_size - 11)
+    {
+      instrument_offsets[instrument_number] = song_pos;
+      song_pos += 11;
+    }
 }
 
 
@@ -630,9 +669,13 @@ void Cu6mPlayer::command_85()
   unsigned char data_byte = read_song_byte();
   int channel = data_byte >> 4; // high nibble
   unsigned char slide_delay = data_byte & 0xF; // low nibble
-  carrier_mf_signed_delta[channel] = +1;
-  carrier_mf_mod_delay[channel] = slide_delay + 1;
-  carrier_mf_mod_delay_backup[channel] = slide_delay + 1;
+
+  if (channel < 9)
+    {
+      carrier_mf_signed_delta[channel] = +1;
+      carrier_mf_mod_delay[channel] = slide_delay + 1;
+      carrier_mf_mod_delay_backup[channel] = slide_delay + 1;
+    }
 }
 
 
@@ -647,9 +690,13 @@ void Cu6mPlayer::command_86()
   unsigned char data_byte = read_song_byte();
   int channel = data_byte >> 4; // high nibble
   unsigned char slide_delay = data_byte & 0xF; // low nibble
-  carrier_mf_signed_delta[channel] = -1;
-  carrier_mf_mod_delay[channel] = slide_delay + 1;
-  carrier_mf_mod_delay_backup[channel] = slide_delay + 1;
+
+  if (channel < 9)
+    {
+      carrier_mf_signed_delta[channel] = -1;
+      carrier_mf_mod_delay[channel] = slide_delay + 1;
+      carrier_mf_mod_delay_backup[channel] = slide_delay + 1;
+    }
 }
 
 
@@ -706,31 +753,29 @@ void Cu6mPlayer::dec_clip(int& param)
 
 // Returns the byte at the current song position.
 // Side effect: increments song_pos.
-unsigned char Cu6mPlayer::read_song_byte()
+int Cu6mPlayer::read_song_byte()
 {
-  unsigned char song_byte;
-  song_byte = song_data[song_pos];
-  song_pos++;
-  return(song_byte);
+  if (song_pos < song_size)
+    {
+      return song_data[song_pos++];
+    }
+  else
+    {
+      return -1;
+    }
 }
 
 
 // Same as read_song_byte(), except that it returns a signed byte
 signed char Cu6mPlayer::read_signed_song_byte()
 {
-  unsigned char song_byte;
-  int signed_value;
-  song_byte = *(song_data + song_pos);
-  song_pos++;
-  if (song_byte <= 127)
+  int song_byte = read_song_byte();
+
+  if (song_byte >= 0x80)
     {
-      signed_value = song_byte;
+      song_byte -= 0x100;
     }
-  else
-    {
-      signed_value = (int)song_byte - 0x100;
-    }
-  return((signed char)signed_value);
+  return song_byte;
 }
 
 

--- a/src/u6m.h
+++ b/src/u6m.h
@@ -161,7 +161,7 @@ class Cu6mPlayer: public CPlayer
 
   // protected functions used by load()
   bool lzw_decompress(data_block source, data_block dest);
-  int get_next_codeword (long& bits_read, unsigned char *source, int codeword_size);
+  int get_next_codeword (long& bits_read, data_block& source, int codeword_size);
   void output_root(unsigned char root, unsigned char *destination, long& position);
   void get_string(int codeword, MyDict& dictionary, std::stack<unsigned char>& root_stack);
 };

--- a/src/u6m.h
+++ b/src/u6m.h
@@ -32,7 +32,7 @@ class Cu6mPlayer: public CPlayer
  public:
   static CPlayer *factory(Copl *newopl);
 
-  Cu6mPlayer(Copl *newopl) : CPlayer(newopl), song_data(0)
+  Cu6mPlayer(Copl *newopl) : CPlayer(newopl), song_data(0), song_size(0)
     {
     };
 
@@ -62,20 +62,20 @@ class Cu6mPlayer: public CPlayer
 
   struct subsong_info   // information about a subsong
   {
-    int continue_pos;
+    size_t continue_pos;
+    size_t subsong_start;
     int subsong_repetitions;
-    int subsong_start;
   };
 
   struct dict_entry   // dictionary entry
   {
     unsigned char root;
-    int codeword;
+    short int codeword;
   };
 
   struct data_block   // 
   {
-    long size;
+    size_t size;
     unsigned char *data;
   };
 
@@ -101,17 +101,16 @@ class Cu6mPlayer: public CPlayer
 
 
   // class variables
-  long played_ticks;
-
   unsigned char* song_data;   // the uncompressed .m file (the "song")
+  size_t song_size;           // allocated size of song_data
   bool driver_active;         // flag to prevent reentrancy
-  bool songend;				// indicates song end
-  int song_pos;               // current offset within the song
-  int loop_position;          // position of the loop point
+  bool songend;	              // indicates song end
+  size_t song_pos;            // current offset within the song
+  size_t loop_position;       // position of the loop point
   int read_delay;             // delay (in timer ticks) before further song data is read
   std::stack<subsong_info> subsong_stack;
 
-  int instrument_offsets[9];  // offsets of the adlib instrument data
+  size_t instrument_offsets[9]; // offsets of the adlib instrument data
   // vibrato ("vb")
   unsigned char vb_current_value[9];
   unsigned char vb_double_amplitude[9];
@@ -128,7 +127,7 @@ class Cu6mPlayer: public CPlayer
 
   // protected functions used by update()
   void command_loop();
-  unsigned char read_song_byte();
+  int read_song_byte();
   signed char read_signed_song_byte();
   void dec_clip(int&);
   byte_pair expand_freq_byte(unsigned char);
@@ -161,8 +160,8 @@ class Cu6mPlayer: public CPlayer
 
   // protected functions used by load()
   bool lzw_decompress(data_block source, data_block dest);
-  int get_next_codeword (long& bits_read, data_block& source, int codeword_size);
-  void output_root(unsigned char root, unsigned char *destination, long& position);
+  int get_next_codeword(unsigned long& bits_read, data_block& source, int codeword_size);
+  bool output_root(unsigned char root, data_block& destination, size_t& position);
   void get_string(int codeword, MyDict& dictionary, std::stack<unsigned char>& root_stack);
 };
 

--- a/src/xad.cpp
+++ b/src/xad.cpp
@@ -82,7 +82,13 @@ bool CxadPlayer::load(const std::string &filename, const CFileProvider &fp)
 	else
 	{
 		// get file size
-		tune_size = fp.filesize(f) - 80;
+		tune_size = fp.filesize(f);
+		if (tune_size <= 80)
+		{
+			fp.close(f);
+			return false;
+		}
+		tune_size -= 80;
 	}
 
 	// load()


### PR DESCRIPTION
This fixes a truckload of invalid memory accesses and other crashes and undefined behavior in several players, including those reported in the issues #85 to #102.
This addresses only obviously invalid code in the files affected by those issues, didn't bother with other bugs or other files; there's probably still a lot of crashing bugs left to be fixed.