### PR TITLE
Make an API that can extract tracked data from the relevant replayers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,7 +79,7 @@ src_libadplug_la_SOURCES = \
 	src/xad.cpp \
 	src/xsm.cpp
 
-src_libadplug_la_LDFLAGS = -release $(PACKAGE_VERSION) -version-info 0
+src_libadplug_la_LDFLAGS = -release $(PACKAGE_VERSION) -version-info 1
 src_libadplug_la_LIBADD = $(libbinio_LIBS)
 
 # -Dstricmp=strcasecmp is a hack. Throughout AdPlug, stricmp() is used to do

--- a/src/cmfmcsop.cpp
+++ b/src/cmfmcsop.cpp
@@ -457,6 +457,37 @@ void CcmfmacsoperaPlayer::processNoteEvent(const CcmfmacsoperaPlayer::NoteEvent 
 		keyOn(channelNr);
 }
 
+void CcmfmacsoperaPlayer::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                                       unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+  note = 0x00; command = TrackedCmdNone; inst = 0x00; volume = 0xff; param = 0x00;
+
+  if (pattern >= nrOfPatterns) return;
+  const Pattern& p = patterns[pattern];
+
+  for (int pi; pi < p.size(); ++pi) {
+    const NoteEvent& n = p[pi];
+    if (n.row > row) return;
+    if (n.row < row) continue;
+    if (n.col == channel) {
+      if (n.note == 1)
+      {
+        command = TrackedCmdPatternBreak;
+        return;
+      }
+      if (n.note == 4)
+      {
+        command = TrackedCmdNoteCut;
+        return;
+      }
+      inst = n.instrument + 1;
+      volume = n.volume;
+      if ((n.note >= 23) && (n.note < 120)) note = n.note;
+      return;
+    }
+  }
+}
+
 bool CcmfmacsoperaPlayer::update()
 {
 	AdPlug_LogWrite( "%2d: ", currentRow);

--- a/src/cmfmcsop.h
+++ b/src/cmfmcsop.h
@@ -43,7 +43,13 @@ public:
 	virtual unsigned int getorders()      { return nrOfOrders; }
 	virtual unsigned int getorder()       { return currentOrderIndex; }
 	virtual unsigned int getrow()         { return currentRow; }
+	virtual unsigned int getrows()        { return 64; }
+	virtual unsigned int getnchans()      { return 11;  /* not 6? */}
 	virtual unsigned int getspeed()       { return 1; }
+	virtual unsigned char getpattern(unsigned long ordr) {if (ordr >= nrOfOrders) return 0; return patternOrder[ordr]; }
+	virtual void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+	                          unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
+
 	virtual unsigned int getinstruments() { return instruments.size(); }
 	virtual std::string getinstrument(unsigned int n) { return instruments[n].name; }
 

--- a/src/hsc.cpp
+++ b/src/hsc.cpp
@@ -74,6 +74,45 @@ bool ChscPlayer::load(const std::string &filename, const CFileProvider &fp)
   return true;
 }
 
+void ChscPlayer::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                              unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+  note = 0; command = TrackedCmdNone; inst = 0; volume = 255; param = 0;
+  if (pattern >= 0xb2) return;
+  if (pattern >= 128) return;
+  if (channel >= 9) return;
+  unsigned char effect = patterns[pattern][row*9+channel].effect;
+  if (patterns[pattern][row*9+channel].note & 128)
+  {
+    inst = effect + 1;
+    return;
+  }
+  note = patterns[pattern][row*9+channel].note;
+  note += 12;
+ if(mtkmode)		// imitate MPU-401 Trakker bug
+   note--;
+
+  switch (effect & 0xf0) {
+    case 0:
+      switch (effect & 0x0f) {
+        case 1: command = TrackedCmdPatternBreak; return;
+        case 3: command = TrackedCmdVolumeFadeIn; param = effect & 0x0f; return;
+        case 4: command = TrackedCmdOPLVoiceMode; return;
+        case 5: command = TrackedCmdOPLDrumMode; return;
+      }
+      return;
+    case 0x10: command = TrackedCmdPitchSlideUp;       param = effect & 0x0f; return;
+    case 0x20: command = TrackedCmdPitchSlideDown;     param = effect & 0x0f; return;
+    //case 0x50: command = TrackedCmdOPLDrumMode; return;
+    case 0x60: command = TrackedCmdOPLFeedback;        param = effect & 0x0f; return;
+    case 0xa0: command = TrackedCmdOPLCarrierVolume;   param = effect & 0x0f; return;
+    case 0xb0: command = TrackedCmdOPLModulatorVolume; param = effect & 0x0f; return;
+    case 0xc0: volume = effect & 0x0f; return;
+    case 0xd0: command = TrackedCmdPatternJumpTo;      param = effect & 0x0f; return;
+    case 0xf0: command = TrackedCmdSpeed;              param = effect & 0x0f; return;
+  }
+}
+
 bool ChscPlayer::update()
 {
   // general vars
@@ -269,6 +308,12 @@ unsigned int ChscPlayer::getorders()
       break;
 
   return poscnt;
+}
+
+unsigned char ChscPlayer::getpattern(unsigned long ordr)
+{
+  if (ordr >= getorders()) return 0;
+  return song[ordr];
 }
 
 unsigned int ChscPlayer::getinstruments()

--- a/src/hsc.h
+++ b/src/hsc.h
@@ -42,6 +42,12 @@ class ChscPlayer: public CPlayer
   unsigned int getorders();
   unsigned int getorder() { return songpos; }
   unsigned int getrow() { return pattpos; }
+  unsigned int getrows() { return 64; }
+  unsigned int getnchans() { return 9; }
+  unsigned char getpattern(unsigned long ordr);
+  void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                    unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
+
   unsigned int getspeed() { return speed; }
   unsigned int getinstruments();
 

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -85,6 +85,11 @@ bool CxadhybridPlayer::xadplayer_load()
 {
 	if(xad.fmt != HYBRID) return false;
 
+	if (tune_size < (0xade + 64*2))
+	{ /* absolute minimum */
+		return false;
+	}
+
 	// load instruments
 	hyb.inst = (hyb_instrument *)&tune[0];
 
@@ -129,6 +134,59 @@ void CxadhybridPlayer::xadplayer_rewind(int subsong)
 	}
 }
 
+void CxadhybridPlayer::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                                    unsigned char &_note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+	_note = 0; command = TrackedCmdNone; inst = 0; volume = 255; param = 0;
+	if ((pattern*9 + channel + 0x1d4) >= tune_size) return; /* buffer overflow */
+
+	unsigned char posoffset = 0xADE + (hyb.order[pattern*9 + channel] * 64 * 2) + (row * 2);
+
+	if ((posoffset + 1) >= tune_size) return; /* buffer overflow */
+
+	unsigned char *pos = &tune[posoffset];
+	// read event
+	unsigned short event = (pos[1] << 8) + pos[0];
+
+	// calculate variables
+	unsigned char  note  =   event >> 9;
+	unsigned char  ins   = ((event & 0x01F0) >> 4);
+	unsigned char  slide =   event & 0x000F;
+
+	// play event
+	switch(note)
+	{
+		case 0x7D: // 0x7D: Set Speed
+			command = TrackedCmdSpeed;
+			param = event & 0xff;
+			return;
+
+		case 0x7E: // 0x7E: Jump Position
+			command = TrackedCmdPatternJumpTo;
+			param = (event & 0xFF) + 1;
+			return;
+
+		case 0x7f:
+			command = TrackedCmdPatternBreak;
+			return;
+
+		case 0x00:
+		case 0x01:
+                        return;
+		default:
+			inst = ins;
+			_note = note + 12 - 2; // note[2] = C#
+
+			// is slide ?
+			if (slide)
+			{
+				command = (slide & 0x08) ? TrackedCmdPitchSlideDown : TrackedCmdPitchSlideUp;
+				param = slide & 0x07;
+			}
+			return;
+	}
+}
+
 void CxadhybridPlayer::xadplayer_update()
 {
 	int i = 0, j = 0;
@@ -144,7 +202,13 @@ void CxadhybridPlayer::xadplayer_update()
 	// process channels
 	for (i=0;i<9;i++)
 	{
-		unsigned char *pos = &tune[0xADE + (hyb.order[hyb.order_pos*9 + i] * 64 * 2) + (patpos * 2)];
+		if ((hyb.order_pos*9 + i + 0x1d4) >= tune_size) { std::cerr << "WARNING1\n"; break; /* buffer overflow */ }
+
+		unsigned char posoffset = 0xADE + (hyb.order[hyb.order_pos*9 + i] * 64 * 2) + (patpos * 2);
+
+		if ((posoffset + 1) >= tune_size) { std::cerr << "WARNING2\n"; break; /* buffer overflow */ }
+
+		unsigned char *pos = &tune[posoffset];
 		// read event
 		unsigned short event = (pos[1] << 8) + pos[0];
 

--- a/src/hybrid.h
+++ b/src/hybrid.h
@@ -82,6 +82,19 @@ protected:
 	// Wraithverge: added this.
 	unsigned int    xadplayer_getspeed();
 
+	unsigned int getpatters() { return 256; } // need to parse data and detect the real length by review of breaks/jumps
+	unsigned int getpattern() { return hyb.order_pos; } // since channels multiplex orders to build a pattern
+	unsigned char getpattern(unsigned long order) { return order; } // since channels multiplex orders to build a pattern
+	unsigned int getorders() { return 256; } // need to parse data and detect the real length by review of breaks/jumps
+	unsigned int getorder() { return hyb.order_pos; };
+	unsigned int getrow() { return hyb.pattern_pos; };
+	unsigned int getrows() { return 0x40; }
+	unsigned int getnchans() { return 9; }
+	unsigned int getspeed() { return plr.speed; }
+
+	void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+		          unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
+
 private:
 	static const unsigned char hyb_adlib_registers[99];
 	static const unsigned short hyb_notes[98];

--- a/src/lds.cpp
+++ b/src/lds.cpp
@@ -155,6 +155,132 @@ bool CldsPlayer::load(const std::string &filename, const CFileProvider &fp)
   return true;
 }
 
+void CldsPlayer::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                              unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+  note = 0; command = TrackedCmdNone; inst = 0; volume = 255; param = 0;
+  if (pattern >= numposi) return;
+  if (row >= pattlen) return;
+  if (channel >= 9) return;
+  unsigned short   patnum = positions[pattern * 9 + channel].patnum;
+  unsigned char transpose = positions[pattern * 9 + channel].transpose;
+  int crow = 0;
+  int packpos = 0;
+
+  while (crow <= row) {
+    unsigned short comword, freq, octave, chan, tune, wibc, tremc, arpreg;
+    bool           vbreak;
+    unsigned char  level, regnum, comhi, comlo;
+    int            i;
+
+    comword = patterns[patnum + packpos];
+    comhi = comword >> 8;
+    comlo = comword & 0xff;
+
+    if(comword) {
+      if(comhi == 0x80) {
+        crow += comlo;
+      } else {
+        if (crow == row) {
+          if(comhi >= 0x80) {
+            switch(comhi) {
+              case 0xff:
+                command = TrackedCmdOPLCarrierModulatorVolume;
+                param = comlo;
+                break;
+              case 0xfe:
+                command = TrackedCmdTempo;
+                param = comword & 0x3f;
+                break;
+              case 0xfd:
+                volume = comlo;
+                break;
+              case 0xfc:
+                command = TrackedCmdNoteCut;
+                break;
+              case 0xfb:
+                command = TrackedCmdRetrigger;
+                param = 1;
+                break;
+              case 0xfa:
+                command = TrackedCmdPatternBreak;
+                break;
+              case 0xf9:
+                command = TrackedCmdPatternJumpTo;
+                param = comlo & maxpos;
+                break;
+              case 0xf8:
+                // lastune = 0 ???
+                break;
+              case 0xf7:
+                command = TrackedCmdVibrato;
+                param = comlo;
+                break;
+              case 0xf6:
+                command = TrackedCmdTonePortamento;
+                note = comlo + 12;
+                param = 0;
+                break;
+              case 0xf5:
+                command = TrackedCmdPitchSlideUpDown; // not a perfect match for c->finetune = comlo
+                param = comlo;
+                break;
+              case 0xf4:
+                command = TrackedCmdGlobalVolume;
+                param = comlo;
+                break;
+              case 0xf3:
+                // fadeonoff = comlo ??
+                command = TrackedCmdVolumeFadeIn;
+                param = comlo;
+                break;
+              case 0xf2:
+                command = TrackedCmdOPLTremolo;
+                param = comlo;
+                break;
+              case 0xf1:	// panorama
+              case 0xf0:	// progch
+                break;
+              default:
+                if(comhi < 0xa0) {
+                  command = TrackedCmdTonePortamento;
+                  // this note might be off..
+                  note = (comhi & 0x1f) + 12;
+                  param = 0;
+                }
+                break;
+            }
+          } else {
+            unsigned char  sound;
+            unsigned short high;
+            signed char transp = transpose & 127;
+
+            if(transpose & 64) transp |= 128;
+
+            if(transpose & 128) {
+              sound = (comlo + transp) & maxsound;
+              high = comhi << 4;
+            } else {
+              sound = comlo & maxsound;
+              high = (comhi + transp) << 4;
+            }
+
+            if(chandelay[chan]) {
+              // command = TrackedCmdDelay;
+              // param = chandelay[chan];
+            }
+            // this note might be off..
+            note = high + 12;
+          }
+          return;
+        }
+        crow++;
+      }
+    }
+    packpos++;
+  }
+}
+
 bool CldsPlayer::update()
 {
   unsigned short	comword, freq, octave, chan, tune, wibc, tremc, arpreg;

--- a/src/lds.h
+++ b/src/lds.h
@@ -37,9 +37,15 @@ class CldsPlayer: public CPlayer
   std::string gettype() { return std::string("LOUDNESS Sound System"); }
   unsigned int getorders() { return numposi; }
   unsigned int getorder() { return posplay; }
+  unsigned char getpattern(unsigned long order) { return order; }
+
   unsigned int getrow() { return pattplay; }
+  unsigned int getrows() { return pattlen; }
+  unsigned int getnchans() { return 9; }
   unsigned int getspeed() { return speed; }
   unsigned int getinstruments() { return numpatch; }
+  void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                    unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
 
  private:
   typedef struct {

--- a/src/player.h
+++ b/src/player.h
@@ -57,11 +57,17 @@ public:
 	  { return 0; }
 	virtual unsigned int getpattern()	// returns currently playing pattern
 	  { return 0; }
+	virtual unsigned char getpattern(unsigned long order) // resolve order into pattern (tracked file formats)
+	  {  return order; }
 	virtual unsigned int getorders()	// returns size of orderlist
 	  { return 0; }
 	virtual unsigned int getorder()		// returns currently playing song position
 	  { return 0; }
 	virtual unsigned int getrow()		// returns currently playing row
+	  { return 0; }
+	virtual unsigned int getrows()         // returns number of rows per pattern (tracked file formats)
+	  { return 0; }
+	virtual unsigned int getnchans()       // returns number of channels per pattern (tracked file formats)
 	  { return 0; }
 	virtual unsigned int getspeed()		// returns current song speed
 	  { return 0; }
@@ -71,6 +77,59 @@ public:
 	  { return 0; }
 	virtual unsigned int getinstruments()	// returns number of instruments
 	  { return 0; }
+	enum TrackedCmds
+	{
+		TrackedCmdNone,
+		TrackedCmdArpeggio,
+		TrackedCmdPitchSlideUp,
+		TrackedCmdPitchSlideDown,
+		TrackedCmdPitchSlideUpDown,
+		TrackedCmdPitchFineSlideUp,
+		TrackedCmdPitchFineSlideDown,
+		TrackedCmdTonePortamento,
+		TrackedCmdTonePortamentoVolumeSlide,
+		TrackedCmdVibratoFine,
+		TrackedCmdVibrato,
+		TrackedCmdVibratoVolumeSlide,
+		TrackedCmdSpeed,
+		TrackedCmdTempo,
+		TrackedCmdReleaseSustainedNotes,
+		TrackedCmdVolumeSlideUpDown,
+		TrackedCmdVolumeFineSlideUp,
+		TrackedCmdVolumeFineSlideDown,
+		TrackedCmdVolumeFadeIn,
+		//TrackedCmdSetVolume,   Use volume as is instead
+
+		TrackedCmdPatternJumpTo,
+		TrackedCmdPatternBreak,
+		TrackedCmdPatternSetLoop,
+		TrackedCmdPatternDoLoop,
+		TrackedCmdPatternDelay,
+
+		TrackedCmdOPLCarrierModulatorVolume,
+		TrackedCmdOPLCarrierVolume,
+		TrackedCmdOPLModulatorVolume,
+		TrackedCmdOPLCarrierModulatorWaveform,
+
+		TrackedCmdOPLTremoloVibrato,
+		TrackedCmdOPLTremolo,
+		TrackedCmdOPLVibrato,
+
+		TrackedCmdOPL3Multiplier,
+		TrackedCmdOPLFeedback,
+		TrackedCmdOPL3Volume,
+
+		TrackedCmdOPLVoiceMode,
+		TrackedCmdOPLDrumMode,
+
+		TrackedCmdRetrigger,
+		TrackedCmdNoteCut,
+
+		TrackedCmdGlobalVolume,
+	};
+	virtual void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+	                          unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param) // retrieve tracked data
+	  { return; }
 	virtual std::string getinstrument(unsigned int n)	// returns n-th instrument name
 	  { return std::string(); }
 

--- a/src/protrack.cpp
+++ b/src/protrack.cpp
@@ -58,6 +58,79 @@ CmodPlayer::~CmodPlayer()
   dealloc();
 }
 
+void CmodPlayer::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                              unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+  note=0; command=TrackedCmdNone; inst=0; volume=255; param=0;
+  if (pattern >= npats) return; //throw std::invalid_argument( "pattern out of range");
+  if (row >= nrows) return; //;throw std::invalid_argument( "row out out of range");
+  if (channel >= nchans) return; //throw std::invalid_argument( "channel out or range");
+  unsigned short track = trackord[pattern][channel];
+  if (!track) return;
+  track--;
+  note = tracks[track][row].note;
+  inst = tracks[track][row].inst;
+  if (note == 127)
+  {
+    note = 0;
+    command = TrackedCmdNoteCut;
+    return;
+  }
+  if(flags & Decimal)
+     param = tracks[track][row].param1 * 10 + tracks[track][row].param2;
+   else
+     param = (tracks[track][row].param1 << 4) + tracks[track][row].param2;
+  switch (tracks[track][row].command)
+  {
+    case 0: if (param) command = TrackedCmdArpeggio; break;
+    case 1:  command = TrackedCmdPitchSlideUp; break;
+    case 2:  command = TrackedCmdPitchSlideDown; break;
+    case 3:  command = TrackedCmdTonePortamento; break;
+    case 4:  command = TrackedCmdVibrato; break;
+    case 5:  command = TrackedCmdTonePortamentoVolumeSlide; break;
+    case 6:  command = TrackedCmdVibratoVolumeSlide; break;
+    case 7:  command = TrackedCmdTempo; break;
+    case 8:  command = TrackedCmdReleaseSustainedNotes; break;
+    case 9:  command = TrackedCmdOPLCarrierModulatorVolume; break;
+    case 10:
+    case 16:
+    case 20:
+    case 26: command = TrackedCmdVolumeSlideUpDown; break;
+    case 11: command = TrackedCmdPatternJumpTo; break;
+    case 12: volume = param; param = 0; break;
+    case 13: command = TrackedCmdPatternBreak; break;
+    case 15:
+    case 18:
+    case 19: command = TrackedCmdSpeed; break;
+    case 17: command = TrackedCmdOPL3Volume; break;
+    case 21: command = TrackedCmdOPLModulatorVolume; break;
+    case 22: command = TrackedCmdOPLCarrierVolume; break;
+    case 23: command = TrackedCmdPitchFineSlideUp; break;
+    case 24: command = TrackedCmdPitchFineSlideDown; break;
+    case 25: command = TrackedCmdOPLCarrierModulatorWaveform; break;
+    case 27: command = TrackedCmdOPLTremoloVibrato; break;
+    case 28: command = TrackedCmdPitchSlideUpDown; break;
+    case 29: command = TrackedCmdPatternDelay; break;
+    case 14:
+      switch (param & 0xf0)
+      {
+        case 0x00: command = TrackedCmdOPLTremolo; param &= 0x0f; break;
+        case 0x10: command = TrackedCmdOPLVibrato; param &= 0x0f; break;
+        case 0x30: command = TrackedCmdRetrigger; param &= 0x0f; break;
+        case 0x40: command = TrackedCmdVolumeFineSlideUp; param &= 0x0f; break;
+        case 0x50: command = TrackedCmdVolumeFineSlideDown; param &= 0x0f; break;
+        case 0x60: command = TrackedCmdPitchFineSlideUp; param &= 0x0f; break;
+        case 0x70: command = TrackedCmdPitchFineSlideDown; param &= 0x0f; break;
+        case 0x80: command = TrackedCmdPatternDelay; param &= 0x0f; break;
+        default: param = 0; break;
+      }
+      break;
+    default:
+      param = 0;
+      break;
+  }
+}
+
 bool CmodPlayer::update()
 {
   unsigned char		pattbreak=0, donote, pattnr, chan, oplchan, info1,

--- a/src/protrack.h
+++ b/src/protrack.h
@@ -35,7 +35,7 @@ public:
   float getrefresh();
 
   unsigned int getpatterns()
-    { return nop; }
+    { return nop ? npats : nop; }
   unsigned int getpattern()
     { return order[ord]; }
   unsigned int getorders()
@@ -44,8 +44,17 @@ public:
     { return ord; }
   unsigned int getrow()
     { return rw; }
+  unsigned int getrows()
+    { return nrows; }
+  unsigned int getnchans()
+    { return nchans; }
   unsigned int getspeed()
     { return speed; }
+
+  unsigned char getpattern(unsigned long _order)
+    { if (_order > length) return 0; return order[_order]; }
+  void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+    unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
 
  protected:
   enum Flags {

--- a/src/rad2.cpp
+++ b/src/rad2.cpp
@@ -546,6 +546,10 @@ public:
 	uint32_t            ComputeTotalTime();
 #endif
 
+	unsigned char       GetTrackFor(unsigned long Ordr);
+	void                GetTuneData(unsigned char TrackNumber, unsigned char linenum, unsigned char channel,
+	                                unsigned char &note, CPlayer::TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
+
 private:
 	bool                UnpackNote(uint8_t *&s, uint8_t &last_instrument);
 	uint8_t *           GetTrack();
@@ -967,8 +971,6 @@ bool RADPlayer::Update() {
 #endif
 }
 
-
-
 //==================================================================================================
 // Unpacks a single RAD note.
 //==================================================================================================
@@ -1067,7 +1069,20 @@ uint8_t *RADPlayer::GetTrack() {
 	return Tracks[track_num];
 }
 
+unsigned char RADPlayer::GetTrackFor(unsigned long Ordr)
+{
+	if (Ordr >= OrderListSize)
+		return 0;
 
+	uint8_t track_num = OrderList[Order];
+
+	if (track_num & 0x80) {
+		Ordr = track_num & 0x7F;
+		track_num = OrderList[Ordr] & 0x7F;
+	}
+
+	return track_num;
+}
 
 //==================================================================================================
 // Skip through track till we reach the given line or the next higher one.  Returns null if none.
@@ -1157,7 +1172,131 @@ void RADPlayer::PlayLine() {
 	}
 }
 
+void RADPlayer::GetTuneData(unsigned char TrackNumber, unsigned char linenum, unsigned char channel,
+                            unsigned char &note, CPlayer::TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+	note = 0; command = CPlayer::TrackedCmdNone; inst = 0; volume = 255; param = 0;
 
+	uint8_t *trk = Tracks[TrackNumber];
+
+	while (1) {
+
+		uint8_t lineid = *trk;
+		if ((lineid & 0x7F) > linenum)
+			return;
+		if (lineid == linenum)
+			break;
+		if (lineid & 0x80)
+			return;
+		trk++;
+
+		// Skip channel notes
+		uint8_t chanid;
+		do {
+			chanid = *trk++;
+			if (Version >= 2)
+				trk += NoteSize[(chanid >> 4) & 7];
+			else if (trk[1] & 0xf)
+				// v1 note with param
+				trk += 3;
+			else
+				// v1 note without param
+				trk += 2;
+		} while (!(chanid & 0x80));
+	}
+
+	// Run through channels
+	uint8_t chanid;
+	do {
+		int channum = *trk & 15;
+		chanid = *trk++;
+
+		if (channum == channel)
+		{
+			uint8_t EffectNum = 0;
+			uint8_t Param = 0;
+
+			if (Version >= 2) {
+				// Version 2 notes
+				// Unpack note data
+				if (chanid & 0x40) {
+					uint8_t n = *trk++;
+					note = n & 0x7F;
+				}
+
+				// Do we have an instrument?
+				if (chanid & 0x20) {
+					inst = *trk++;
+				}
+
+				// Do we have an effect?
+				if (chanid & 0x10) {
+					EffectNum = *trk++;
+					Param = *trk++;
+				}
+			}
+			else {
+				// Version 1 notes
+				// Unpack note data
+				uint8_t n = *trk++;
+				note = n & 0x7f;
+				if (n & 0x80)
+					inst = 16;
+
+				// Do we have an instrument?
+				n = *trk++;
+				inst |= n >> 4;
+
+				// Do we have an effect?
+				EffectNum = n & 0xf;
+				if (EffectNum)
+					Param = *trk++;
+			}
+
+			if (note)
+			{
+				if ((note & 0x0f) == 0x0f)
+				{
+					note = 0;
+                                        command = CPlayer::TrackedCmdNoteCut;
+                                        return;
+				} else {
+					note = (note & 0x0f) + ((note >> 4) + 1) * 12 + 1; /* C# is the base note */
+				}
+			}
+
+			switch (EffectNum)
+			{
+				case cmPortamentoUp:  command=CPlayer::TrackedCmdPitchSlideUp;              param=Param; return;
+				case cmPortamentoDwn: command=CPlayer::TrackedCmdPitchSlideDown;            param=Param; return;
+				case cmToneSlide:     command=CPlayer::TrackedCmdTonePortamento;            param=Param; return;
+				case cmToneVolSlide:  command=CPlayer::TrackedCmdTonePortamentoVolumeSlide; param=Param; return;
+				case cmVolSlide:      command=CPlayer::TrackedCmdVolumeSlideUpDown;         param=Param; return;
+				case cmSetVol: volume=Param; return;
+				case cmJumpToLine:    command=CPlayer::TrackedCmdPatternJumpTo;             param=Param; return;
+				case cmSetSpeed:      command=CPlayer::TrackedCmdSpeed;                     param=Param; return;
+				case cmIgnore: return; // NoRiff....
+				case cmMultiplier:    command=CPlayer::TrackedCmdOPL3Multiplier;            param=Param; return;
+				case cmRiff: return; // Maybe arpeggio is the closest?
+				case cmTranspose: return; // Has to do with the riff?
+				case cmFeedback:      command=CPlayer::TrackedCmdOPLFeedback;               param=Param; return;
+				case cmVolume:        command=CPlayer::TrackedCmdOPL3Volume;                param=Param; return;
+			}
+			return;
+		}
+
+		if (Version >= 2)
+			trk += NoteSize[(chanid >> 4) & 7];
+		else if (trk[1] & 0xf)
+			// v1 note with param
+			trk += 3;
+		else
+			// v1 note without param
+			trk += 2;
+	} while (!(chanid & 0x80));
+
+	return;
+}
 
 //==================================================================================================
 // Play a single note.  Returns the line number in the next pattern to jump to if a jump command was
@@ -1928,6 +2067,11 @@ unsigned int Crad2Player::getpattern() { return rad->GetTunePattern(); }
 unsigned int Crad2Player::getorders() { return rad->GetTuneLength(); }
 unsigned int Crad2Player::getorder() { return rad->GetTunePos(); }
 unsigned int Crad2Player::getrow() { return rad->GetTuneLine(); }
+unsigned int Crad2Player::getrows() { return 64; /* rad->kTrackLines; */ }
+unsigned char Crad2Player::getpattern(unsigned long order) { return rad->GetTrackFor(order); }
+void Crad2Player::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+	                       unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param) { rad->GetTuneData(pattern, row, channel, note, command, inst, volume, param); }
+unsigned int Crad2Player::getnchans() {return 16; }
 unsigned int Crad2Player::getspeed() { return rad->GetSpeed(); }
 unsigned int Crad2Player::getinstruments() { return rad->GetTuneInsts(); }
 std::string Crad2Player::getinstrument(unsigned int n) { return rad->GetTuneInst(n); }

--- a/src/rad2.h
+++ b/src/rad2.h
@@ -50,6 +50,11 @@ public:
 	unsigned int getorders();
 	unsigned int getorder();
 	unsigned int getrow();
+	unsigned int getrows();
+	unsigned int getnchans();
+	unsigned char getpattern(unsigned long order);
+	void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+	                  unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
 	unsigned int getspeed();
 	std::string getinstrument(unsigned int n);
 

--- a/src/rat.cpp
+++ b/src/rat.cpp
@@ -138,6 +138,37 @@ static unsigned char calc_volume(unsigned char ivol, unsigned char cvol, unsigne
   return vol;
 }
 
+void CxadratPlayer::gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                                unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+  note = 0; command = TrackedCmdNone; inst = 0; volume = 255; param = 0;
+  if (pattern >= rat.hdr.numpat) return;
+  if (channel >= rat.hdr.numchan) return;
+  if (row >= 64) return;
+
+  const rat_event &event = rat.tracks[pattern][row][channel];
+
+  if (event.instrument != 0xff) inst = event.instrument;
+  volume = event.volume; /* 0xff == none */
+
+  if (event.note != 0xff) note = (event.note & 0x0f) + ((event.note >> 4) + 2) * 12;
+
+  switch (event.fx)
+  {
+    case 0x01:
+      command = TrackedCmdSpeed;
+      param = event.fxp;
+      return;
+    case 0x02:
+      command = TrackedCmdPatternJumpTo;
+      param = event.fxp;
+      return;
+    case 0x03:
+      command = TrackedCmdPatternBreak;
+      return;
+  }
+}
+
 void CxadratPlayer::xadplayer_update()
 {
   unsigned char pattern = rat.order[rat.order_pos];

--- a/src/rat.h
+++ b/src/rat.h
@@ -112,4 +112,21 @@ protected:
   std::string     xadplayer_gettype();
   std::string     xadplayer_gettitle();
   unsigned int    xadplayer_getinstruments();
+
+  unsigned int getpatterns() { return rat.hdr.numpat; }
+  unsigned int getpattern() { return rat.order[rat.order_pos]; }
+  unsigned char getpattern(unsigned long order)
+  {
+    if (order >= rat.hdr.order_end ) return 0;
+    return rat.order[order];
+  }
+  unsigned int getorders() { return rat.hdr.order_end; }
+  unsigned int getorder() { return rat.order_pos; }
+  unsigned int getrow() { return rat.pattern_pos; }
+  unsigned int getrows() { return 64; }
+  unsigned int getnchans() { return rat.hdr.numchan; }
+  unsigned int getspeed() { return plr.speed; }
+  void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                    unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
+
 };

--- a/src/s3m.cpp
+++ b/src/s3m.cpp
@@ -64,6 +64,84 @@ Cs3mPlayer::Cs3mPlayer(Copl *newopl): CPlayer(newopl)
       }
 }
 
+unsigned int Cs3mPlayer::getnchans()
+{
+  int retval = 0;
+  for (int chan=0; chan < 32; chan++)
+    if ((!(header.chanset[chan] & 0x80)) &&
+        (chnresolv[header.chanset[chan] & 0x1f] >= 0))
+      retval++;
+  return retval;
+}
+
+void Cs3mPlayer::gettrackdata(unsigned char pattrn, unsigned char row, unsigned char channel,
+                              unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param)
+{
+  note=0; command=TrackedCmdNone; inst=0; volume=255; param = 0;
+  if (pattrn >= header.patnum) return;
+  if (row >= 64) return;
+  int chanreverse = 0;
+  for (int chan=0; chan < 32; chan++) {
+    if ((!(header.chanset[chan] & 0x80)) &&
+        (chnresolv[header.chanset[chan] & 0x1f] >= 0)) {
+      if (chanreverse == channel) {
+        const s3mevent &ev = pattern[pattrn][row][chan];
+        inst = ev.instrument;
+        volume = ev.volume;
+        if (ev.note < 12) {
+          note = ev.note + ev.oct*12 + 12;
+        } else if (ev.note == 14) {
+          command = TrackedCmdNoteCut;
+          return;
+        }
+        param = ev.info;
+        switch (ev.command) {
+          case 1: command = TrackedCmdSpeed; break;
+          case 2: command = TrackedCmdPatternJumpTo; break;
+          case 3: command = TrackedCmdPatternBreak; break;
+          case 4: command = TrackedCmdVolumeSlideUpDown; break;
+          case 5:
+            if (ev.info > 0xf0) {
+              command = TrackedCmdVolumeFineSlideUp;
+              param = ev.info & 15;
+            } else if (((ev.info & 0x0f) == 0x0f) && (ev.info & 0xf0)) {
+              command = TrackedCmdVolumeFineSlideDown;
+              param = ev.info >> 4;
+            }
+            break;
+          case 6:
+            if (ev.info > 0xf0) {
+              command = TrackedCmdPitchFineSlideUp;
+              param = ev.info & 15;
+            } else if (((ev.info & 0x0f) == 0x0f) && (ev.info & 0xf0)) {
+              command = TrackedCmdPitchFineSlideDown;
+              param = ev.info >> 4;
+            }
+            break;
+          case 7: command = TrackedCmdTonePortamento; break;
+          case 8: command = TrackedCmdVibrato; break;
+          case 10: if (param) command = TrackedCmdArpeggio; break;
+          case 11: command = TrackedCmdVibratoVolumeSlide; break;
+          case 12: command = TrackedCmdTonePortamentoVolumeSlide; break;
+          case 19:
+            if (ev.info == 0xb0) {
+              command = TrackedCmdPatternSetLoop;
+              param = 0;
+            } else if ((ev.info & 0xf0 ) == 0xb0) {
+              command = TrackedCmdPatternDoLoop;
+              param &= 0x0f;
+            }
+            break;
+          case 20: command = TrackedCmdTempo; break;
+          case 21: command = TrackedCmdSpeed; break;
+        }
+        return;
+      }
+      chanreverse++;
+    }
+  }
+}
+
 bool Cs3mPlayer::load(const std::string &filename, const CFileProvider &fp)
 {
   binistream		*f = fp.open(filename); if(!f) return false;

--- a/src/s3m.h
+++ b/src/s3m.h
@@ -50,8 +50,20 @@ class Cs3mPlayer: public CPlayer
     { return ord; };
   unsigned int getrow()
     { return crow; };
+  unsigned int getrows()
+    { return 64; }
+  unsigned int getnchans();
+  void gettrackdata(unsigned char pattern, unsigned char row, unsigned char channel,
+                    unsigned char &note, TrackedCmds &command, unsigned char &inst, unsigned char &volume, unsigned char &param);
   unsigned int getspeed()
     { return speed; };
+
+  unsigned char getpattern(unsigned long ord)
+    {
+      unsigned char pattnr = ord < header.ordnum ? orders[ord] : 0xff;
+      return pattnr;
+    }
+
   unsigned int getinstruments()
     { return header.insnum; };
   std::string getinstrument(unsigned int n)


### PR DESCRIPTION
Base class and relevant players implements the follow new API calls
 * getpattern(int order) resolves order to pattern-index
 * getrows() how long are each pattern (normally 64)
 * getnchans() how many channels/tracks are each pattern
 * gettrackdata() return track data for a given pattern/row/channel combinations (some replayers could benefit from unfolding tracked data from byte-streams into actually pattern-arrays to speed this up)

Bump the .so file version, since the core base-class has changed slightly

CxadhybridPlayer
 * Added some buffer-overflow protections in loader/player
 
 This makes it possible to expose visual tracker data from some of the replayers:
![Screenshot at 2022-02-06 13-15-17](https://user-images.githubusercontent.com/12225220/152680315-e64fe586-9d6c-43fb-bbc7-d08d65c3aba7.png)
