### PR TITLE
Add missing RAD2 test files to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,6 +278,8 @@ EXTRA_DIST += \
 	test/bmf1_2.xad \
 	test/BOOTUP.M \
 	test/BOOTUP.ref \
+	test/canonind.rad \
+	test/canonind.ref \
 	test/CHILD1.ref \
 	test/CHILD1.XSM \
 	test/crusader.raw \
@@ -292,6 +294,8 @@ EXTRA_DIST += \
 	test/DTM-TRK1.ref \
 	test/DUNE19.ADL \
 	test/DUNE19.ref \
+	test/dystopia.rad \
+	test/dystopia.ref \
 	test/ending.ref \
 	test/ending.sop \
 	test/EOBSOUND.ADL \


### PR DESCRIPTION
Since 09b4a007a33de41b8eb5ce1eb491687f43c263be, playertest needs these two files. However, they weren't listed in EXTRA_DIST, so they were missing from the 2.3.3 tarball, which means running the test suite from the tarball fails.