### PR TITLE
Fix a crash with RAD2 files

### DIFF
--- a/src/rad2.cpp
+++ b/src/rad2.cpp
@@ -709,6 +709,9 @@ void RADPlayer::Init(const void *tune, void(*opl3)(void *, uint16_t, uint8_t), v
 		s++;
 	}
 
+	// Blank the instrument table, some files reference non-existent instruments
+	memset(&Instruments[0], 0, sizeof(Instruments));
+
 	// Unpack the instruments
 	NumInstruments = 0;
 	while (1) {


### PR DESCRIPTION
Affected files: xmasong.rad, possibly others

Song references unused instruments not included in the file, causing uninitialized instrument Riff member to be dereferenced, which ends up pointing at unallocated memory.