### PR TITLE
Include debug.h in coktel.cpp.

### DIFF
--- a/src/coktel.cpp
+++ b/src/coktel.cpp
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "coktel.h"
+#include "debug.h"
 
 /*** public methods *************************************/
 


### PR DESCRIPTION
The file `coktel.cpp` does two log writes (on line [214](https://github.com/adplug/adplug/blob/ba20f6e4405590974686d3fbea2a7abdabb5b511/src/coktel.cpp#L214) and [222](https://github.com/adplug/adplug/blob/ba20f6e4405590974686d3fbea2a7abdabb5b511/src/coktel.cpp#L222)), but does not include `debug.h`.
