### PR TITLE
Fix minor -Wreoder warning

### DIFF
--- a/src/coktel.h
+++ b/src/coktel.h
@@ -49,7 +49,7 @@ public:
 	static CPlayer *factory(Copl *newopl);
 
 	CcoktelPlayer(Copl *newopl)
-		: CcomposerBackend(newopl), insts(0), data(0)
+		: CcomposerBackend(newopl), data(0), insts(0)
 		{ }
 	~CcoktelPlayer()
 	{


### PR DESCRIPTION
src/coktel.h: In constructor ‘CcoktelPlayer::CcoktelPlayer(Copl*)’: src/coktel.h:101:25: warning: ‘CcoktelPlayer::insts’ will be initialized after [-Wreorder]
  101 |         adl_inst *      insts;                                  /* instrument definitions */
      |                         ^~~~~
src/coktel.h:86:25: warning:   ‘uint8_t* CcoktelPlayer::data’ [-Wreorder]
   86 |         uint8_t *       data;                                   /* MIDI data */
      |                         ^~~~
src/coktel.h:51:9: warning:   when initialized here [-Wreorder]
   51 |         CcoktelPlayer(Copl *newopl)
      |         ^~~~~~~~~~~~~