### PR TITLE
Fix for a2m -Wsign-compare

### DIFF
--- a/src/a2m.cpp
+++ b/src/a2m.cpp
@@ -47,7 +47,8 @@ CPlayer *Ca2mLoader::factory(Copl *newopl)
 bool Ca2mLoader::load(const std::string &filename, const CFileProvider &fp)
 {
   binistream *f = fp.open(filename); if (!f) return false;
-  int i, j, k, t;
+  unsigned int i;
+  int j, k, t;
   unsigned int l;
   unsigned char *org, *orgptr, flags = 0;
   unsigned long alength;
@@ -199,7 +200,7 @@ bool Ca2mLoader::load(const std::string &filename, const CFileProvider &fp)
     orgptr = org + alength;
   }
 
-  if (orgptr - org < needed) {
+  if (orgptr - org < (ssize_t)needed) {
     delete [] org;
     fp.close(f);
     return false;


### PR DESCRIPTION
src/a2m.cpp: In member function ‘virtual bool Ca2mLoader::load(const string&, const CFileProvider&)’: src/a2m.cpp:162:17: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  162 |   for (i = 0; i < length; i++)
src/a2m.cpp: In member function ‘virtual bool Ca2mLoader::load(const string&, const CFileProvider&)’:
src/a2m.cpp:203:20: warning: comparison of integer expressions of different signedness: ‘long int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  203 |   if (orgptr - org < needed) {