### PR TITLE
Fix Wsign-compare in cff.cpp

### DIFF
--- a/src/cff.cpp
+++ b/src/cff.cpp
@@ -103,7 +103,7 @@ bool CcffLoader::load(const std::string &filename, const CFileProvider &fp)
 
   // number of patterns
   nop = module[0x5E0];
-  if (nop < 1 || nop > 36 || 0x669 + nop * 64 * 9 * 3 > module_size) {
+  if (nop < 1 || nop > 36 || (size_t)0x669 + nop * 64 * 9 * 3 > module_size) {
     delete [] module;
     return false;
   }


### PR DESCRIPTION
Fix this warning by typecasting 0x669 that defaults to int into the type of module_size, size_t

```
src/cff.cpp: In member function ‘virtual bool CcffLoader::load(const string&, const CFileProvider&)’: src/cff.cpp:106:55: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  106 |   if (nop < 1 || nop > 36 || 0x669 + nop * 64 * 9 * 3 > module_size) {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```