### PR TITLE
Fix these warnings and simplify some logic by using unsigned datatypes instead of signed at some locations.

### DIFF
--- a/src/cmfmcsop.cpp
+++ b/src/cmfmcsop.cpp
@@ -197,7 +197,7 @@ bool CcmfmacsoperaPlayer::loadInstruments(binistream* f, int nrOfInstruments)
 	};
 
 	for (int i = 0; i < nrOfInstruments; ++i) {
-		for (int j = 0; j < sizeof(loadOffsets)/sizeof(loadOffsets[0]); ++j) {
+		for (unsigned int j = 0; j < sizeof(loadOffsets)/sizeof(loadOffsets[0]); ++j) {
 			int v = f->readInt(2);
 			if (loadOffsets[j] >= 0 ) {
 				*(int16_t*)((char*)&instruments[i] + loadOffsets[j]) = v;
@@ -403,7 +403,7 @@ void CcmfmacsoperaPlayer::setVolume(int channelNr, int vol)
 bool CcmfmacsoperaPlayer::advanceRow()
 {
 	for (;;) {
-		if (currentRow < 0 || ++currentRow >= 64) {
+		if (++currentRow >= 64) {
 			// next pattern
 			currentRow = 0;
 			currentPatternIndex = 0;
@@ -412,7 +412,7 @@ bool CcmfmacsoperaPlayer::advanceRow()
 				currentOrderIndex++;
 
 				// check bounds
-				if (currentOrderIndex < 0 || currentOrderIndex >= sizeof(patternOrder) / sizeof(patternOrder[0]))
+				if (currentOrderIndex >= (sizeof(patternOrder) / sizeof(patternOrder[0])))
 					return false;
 
 				// end of song?
@@ -427,7 +427,7 @@ bool CcmfmacsoperaPlayer::advanceRow()
 		// check for pattern break
 		const Pattern &p = patterns[patternOrder[currentOrderIndex]];
 		if (currentPatternIndex < p.size() && p[currentPatternIndex].row == currentRow && p[currentPatternIndex].note == 1) {
-			currentRow = -1;
+			currentRow = ~0;
 		}
 		else // no pattern break, done!
 			break;
@@ -459,7 +459,7 @@ void CcmfmacsoperaPlayer::processNoteEvent(const CcmfmacsoperaPlayer::NoteEvent 
 
 bool CcmfmacsoperaPlayer::update()
 {
-	AdPlug_LogWrite( "%2d: ", currentRow);
+	AdPlug_LogWrite( "%2u: ", currentRow);
 
 	const Pattern& p = patterns[patternOrder[currentOrderIndex]];
 
@@ -491,8 +491,8 @@ bool CcmfmacsoperaPlayer::update()
 
 void CcmfmacsoperaPlayer::resetPlayer()
 {
-	currentRow = -1;
-	currentOrderIndex = -1;
+	currentRow = ~0;
+	currentOrderIndex = ~0;
 	advanceRow();
 }
 

--- a/src/cmfmcsop.cpp
+++ b/src/cmfmcsop.cpp
@@ -409,7 +409,7 @@ bool CcmfmacsoperaPlayer::advanceRow()
 			currentPatternIndex = 0;
 
 			do {
-				currentOrderIndex++;
+				currentOrderIndex++; // overflows ~0 into 0 when needed
 
 				// check bounds
 				if (currentOrderIndex >= (sizeof(patternOrder) / sizeof(patternOrder[0])))
@@ -421,13 +421,13 @@ bool CcmfmacsoperaPlayer::advanceRow()
 
 			} while (patternOrder[currentOrderIndex] >= patterns.size()); // loop to skip invalid pattern references
 
-			AdPlug_LogWrite("order %d, pattern %d\n", currentOrderIndex, patternOrder[currentOrderIndex]);
+			AdPlug_LogWrite("order %u, pattern %d\n", currentOrderIndex, patternOrder[currentOrderIndex]);
 		}
 
 		// check for pattern break
 		const Pattern &p = patterns[patternOrder[currentOrderIndex]];
 		if (currentPatternIndex < p.size() && p[currentPatternIndex].row == currentRow && p[currentPatternIndex].note == 1) {
-			currentRow = ~0;
+			currentRow = 64;
 		}
 		else // no pattern break, done!
 			break;
@@ -491,7 +491,7 @@ bool CcmfmacsoperaPlayer::update()
 
 void CcmfmacsoperaPlayer::resetPlayer()
 {
-	currentRow = ~0;
+	currentRow = 64;
 	currentOrderIndex = ~0;
 	advanceRow();
 }

--- a/src/cmfmcsop.h
+++ b/src/cmfmcsop.h
@@ -85,16 +85,16 @@ public:
 	bool    rhythmMode;
 	bool    songDone;
 
-	int     nrOfPatterns;
-	int16_t patternOrder[99];
-	int     nrOfOrders;
+	int      nrOfPatterns;
+	uint16_t patternOrder[99];
+	int      nrOfOrders;
 
 	std::vector<Instrument> instruments;
 	std::vector<Pattern> patterns;
 	
-	int currentOrderIndex;
-	int currentRow;
-	int currentPatternIndex;
+	unsigned int currentOrderIndex;
+	unsigned int currentRow;
+	unsigned int currentPatternIndex;
 	
     const Instrument* channelCurrentInstrument[11];
 	int current0xBx[9];


### PR DESCRIPTION
```
src/cmfmcsop.cpp: In member function ‘bool CcmfmacsoperaPlayer::loadInstruments(binistream*, int)’: src/cmfmcsop.cpp:200:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  200 |                 for (int j = 0; j < sizeof(loadOffsets)/sizeof(loadOffsets[0]); ++j) {
      |                                 ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/cmfmcsop.cpp: In member function ‘bool CcmfmacsoperaPlayer::advanceRow()’:
src/cmfmcsop.cpp:415:80: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  415 |                                 if (currentOrderIndex < 0 || currentOrderIndex >= sizeof(patternOrder) / sizeof(patternOrder[0]))
      |                                                              ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/cmfmcsop.cpp:422:66: warning: comparison of integer expressions of different signedness: ‘int16_t’ {aka ‘short int’} and ‘std::vector<std::vector<CcmfmacsoperaPlayer::NoteEvent> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  422 |                         } while (patternOrder[currentOrderIndex] >= patterns.size()); // loop to skip invalid pattern references
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
src/cmfmcsop.cpp:429:41: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<CcmfmacsoperaPlayer::NoteEvent>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  429 |                 if (currentPatternIndex < p.size() && p[currentPatternIndex].row == currentRow && p[currentPatternIndex].note == 1) {
      |                     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
src/cmfmcsop.cpp: In member function ‘virtual bool CcmfmacsoperaPlayer::update()’:
src/cmfmcsop.cpp:467:36: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<CcmfmacsoperaPlayer::NoteEvent>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  467 |         for (; currentPatternIndex < p.size() && p[currentPatternIndex].row == currentRow; ++currentPatternIndex) {
      |                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```