### PR TITLE
Fix Wsign-compare in composer.cff

### DIFF
--- a/src/composer.cpp
+++ b/src/composer.cpp
@@ -382,7 +382,7 @@ void CcomposerBackend::SetDefaultInstrument(int const voice)
     // waveform select is always equal to 0 here, so just memset
     memset(&data[0], 0, sizeof(data));
 
-    for (int i = 0; i < sizeof(pianoParamsOp0) - 1; i++)
+    for (unsigned int i = 0; i < sizeof(pianoParamsOp0) - 1; i++)
     {
         if ((voice < kBassDrumChannel) || !mRhythmMode)
         {


### PR DESCRIPTION
Fix this warning by making i unsigned. We do not use the negative part of the range.

```
src/composer.cpp: In member function ‘void CcomposerBackend::SetDefaultInstrument(int)’: src/composer.cpp:385:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  385 |     for (int i = 0; i < sizeof(pianoParamsOp0) - 1; i++)
      |                     ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```