### PR TITLE
Fix for d00-Wsign-compare

### DIFF
--- a/src/d00.cpp
+++ b/src/d00.cpp
@@ -462,7 +462,7 @@ void Cd00Player::rewind(int subsong)
 
   size_t dataofs = subsong * sizeof(Stpoin)
     + LE_WORD(&(version > 1 ? header->tpoin : header1->tpoin));
-  if (subsong < getsubsongs() && dataofs + sizeof(Stpoin) <= filesize)
+  if ((unsigned int)subsong < getsubsongs() && dataofs + sizeof(Stpoin) <= filesize)
     memcpy(&tpoin, filedata + dataofs, sizeof(Stpoin));
   else
     memset(&tpoin, 0, sizeof(Stpoin));


### PR DESCRIPTION
```
src/d00.cpp: In member function ‘virtual void Cd00Player::rewind(int)’: src/d00.cpp:465:15: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
  465 |   if (subsong < getsubsongs() && dataofs + sizeof(Stpoin) <= filesize)
      |       ~~~~~~~~^~~~~~~~~~~~~~~
```