### PR TITLE
Fix for dro2-Wsign-compare and convert some additional variables from signed into unsigned 

### DIFF
--- a/src/dro2.cpp
+++ b/src/dro2.cpp
@@ -64,8 +64,8 @@ bool Cdro2Player::load(const std::string &filename, const CFileProvider &fp)
 		return false;
 	}
 
-	this->iLength = f->readInt(4); // should better use an unsigned type
-	if (this->iLength <= 0 || this->iLength >= 1<<30 ||
+	this->iLength = f->readInt(4);
+	if (this->iLength >= 1<<30 ||
 	    this->iLength > fp.filesize(f) - f->pos()) {
 		fp.close(f);
 		return false;
@@ -141,8 +141,8 @@ end_section:
 bool Cdro2Player::update()
 {
 	while (this->iPos < this->iLength) {
-		int iIndex = this->data[this->iPos++];
-		int iValue = this->data[this->iPos++];
+		unsigned int iIndex = this->data[this->iPos++];
+		unsigned int iValue = this->data[this->iPos++];
 
 		// Short delay
 		if (iIndex == this->iCmdDelayS) {

--- a/src/dro2.h
+++ b/src/dro2.h
@@ -33,13 +33,13 @@ class Cdro2Player: public CPlayer
 {
 	protected:
 		uint8_t iCmdDelayS, iCmdDelayL;
-		int iConvTableLen;
+		uint8_t iConvTableLen;
 		uint8_t *piConvTable;
 
 		uint8_t *data;
-		int iLength;
-		int iPos;
-		int iDelay;
+		unsigned int iLength;
+		unsigned int iPos;
+		unsigned int iDelay;
 
 	private:
 		char title[40];


### PR DESCRIPTION
Fix this warning and make some more of the logic work with unsigned instead of signed datatypes.

```
src/dro2.cpp: In member function ‘virtual bool Cdro2Player::load(const string&, const CFileProvider&)’: src/dro2.cpp:69:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   69 |             this->iLength > fp.filesize(f) - f->pos()) {
      |             ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```