### PR TITLE
Fix for dro-Wsign-compare and convert some additional variables from signed into unsigned

### DIFF
--- a/src/dro.cpp
+++ b/src/dro.cpp
@@ -96,7 +96,7 @@ bool CdroPlayer::load(const std::string &filename, const CFileProvider &fp)
 	}
 
 	// Read the OPL data.
-	for (; (int)i < this->iLength; i++) {
+	for (; i < this->iLength; i++) {
 		this->data[i]=f->readInt(1);
 	}
 
@@ -147,8 +147,8 @@ end_section:
 
 bool CdroPlayer::update()
 {
-	int iIndex;
-	int iValue;
+	unsigned int iIndex;
+	unsigned int iValue;
 	while (this->iPos < this->iLength) {
 		iIndex = this->data[this->iPos++];
 

--- a/src/dro.h
+++ b/src/dro.h
@@ -38,9 +38,9 @@ class CdroPlayer: public CPlayer
 		static const uint8_t iCmdDelayL = 0x01; // Wraithverge: fixed this with "static".
 
 		uint8_t *data;
-		int iLength;
-		int iPos;
-		int iDelay;
+		unsigned int iLength;
+		unsigned int iPos;
+		unsigned int iDelay;
 
 	private:
 		char title[40];


### PR DESCRIPTION
Fix this warning and make some more of the logic work with unsigned instead of signed datatypes.

```
src/dro.cpp: In member function ‘virtual bool CdroPlayer::load(const string&, const CFileProvider&)’: src/dro.cpp:76:48: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   76 |         if (this->iLength < 3 || this->iLength > fp.filesize(f) - f->pos()) {
      |                                  ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```