### PR TITLE
Fix for dtm-Wsign-compare

### DIFF
--- a/src/dtm.cpp
+++ b/src/dtm.cpp
@@ -131,7 +131,7 @@ bool CdtmLoader::load(const std::string &filename, const CFileProvider &fp)
 
       f->readString((char *)instruments[i].data, sizeof(instruments[i].data));
 
-      for (int j = 0; j < sizeof(conv_inst); j++)
+      for (unsigned int j = 0; j < sizeof(conv_inst); j++)
 	inst[i].data[conv_inst[j]] = instruments[i].data[j];
   }
 
@@ -218,7 +218,7 @@ bool CdtmLoader::load(const std::string &filename, const CFileProvider &fp)
 
   // order length
   length = N_ORD;
-  for (int i = 0; i < N_ORD; i++) {
+  for (unsigned int i = 0; i < N_ORD; i++) {
       if (order[i] & 0x80) {
 	  length = i;
 


### PR DESCRIPTION
Fix these warnings:

```
src/dtm.cpp: In member function ‘virtual bool CdtmLoader::load(const string&, const CFileProvider&)’: src/dtm.cpp:134:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  134 |       for (int j = 0; j < sizeof(conv_inst); j++)
      |                       ~~^~~~~~~~~~~~~~~~~~~
src/dtm.cpp:230:26: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘int’ [-Wsign-compare]
  230 |           if (restartpos >= i) // bad restart position or empty order list
      |               ~~~~~~~~~~~^~~~
```