### PR TITLE
Fix for herad-Wsign-compare and convert some additional variables from signed into unsigned

### DIFF
--- a/src/herad.cpp
+++ b/src/herad.cpp
@@ -663,9 +663,9 @@ void CheradPlayer::rewind(int subsong)
 	wTime = 0;
 	songend = false;
 
-	ticks_pos = -1; // there's always 1 excess tick at start
+	ticks_pos = ~0; // there's always 1 excess tick at start
 	total_ticks = 0;
-	loop_pos = -1;
+	loop_pos = ~0;
 	loop_times = 1;
 
 	for (int i = 0; i < nTracks; i++)

--- a/src/herad.h
+++ b/src/herad.h
@@ -146,7 +146,7 @@ private:
 protected:
 	bool songend;
 	int16_t wTime;
-	int32_t ticks_pos;	/* current tick counter */
+	uint32_t ticks_pos;	/* current tick counter */
 	uint32_t total_ticks;	/* total ticks in song */
 
 	uint8_t comp;		/* File compression type (see HERAD_COMP_*) */
@@ -236,7 +236,7 @@ protected:
 	herad_chn * chn;					/* active channels [nTracks] */
 	herad_inst * inst;				/* instruments [nInsts] */
 
-	int32_t loop_pos;
+	uint32_t loop_pos;
 	uint16_t loop_times;
 	herad_trk loop_data[HERAD_MAX_TRACKS];
 };


### PR DESCRIPTION
Fix this warning by using unsigned variable/logic instead where needed.

```
src/herad.cpp: In member function ‘void CheradPlayer::processEvents()’: src/herad.cpp:1252:50: warning: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
 1252 |         if (wLoopStart && wLoopEnd && (ticks_pos == total_ticks || (ticks_pos % HERAD_MEASURE_TICKS == 0 && ticks_pos / HERAD_MEASURE_TICKS + 1 == wLoopEnd)))
      |                                        ~~~~~~~~~~^~~~~~~~~~~~~~
```