### PR TITLE
Fix for jbm-Wsign-compare

### DIFF
--- a/src/jbm.cpp
+++ b/src/jbm.cpp
@@ -65,9 +65,9 @@ CPlayer *CjbmPlayer::factory(Copl *newopl)
 
 bool CjbmPlayer::load(const std::string &filename, const CFileProvider &fp)
 {
-  binistream	*f = fp.open(filename); if(!f) return false;
-  int		filelen = fp.filesize(f);
-  int		i;
+  binistream    *f = fp.open(filename); if(!f) return false;
+  unsigned int   filelen = fp.filesize(f);
+  int            i;
 
   if (!filelen || !fp.extension(filename, ".jbm")) goto loaderr;
 


### PR DESCRIPTION
Fix this warning:

```
src/jbm.cpp: In member function ‘virtual bool CjbmPlayer::load(const string&, const CFileProvider&)’: src/jbm.cpp:77:41: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘int’ [-Wsign-compare]
   77 |   if (f->readString((char *)m, filelen) != filelen) goto loaderr;
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```