### PR TITLE
Fix for mid-Wsign-compare and convert some additional variables from signed into unsigned 

### DIFF
--- a/src/mid.cpp
+++ b/src/mid.cpp
@@ -143,9 +143,9 @@ CmidPlayer::CmidPlayer(Copl *newopl)
 {
 }
 
-unsigned char CmidPlayer::datalook(long pos)
+unsigned char CmidPlayer::datalook(unsigned long pos)
 {
-    if (pos<0 || pos >= flen) return(0);
+    if (pos >= flen) return(0);
     return(data[pos]);
 }
 
@@ -1009,15 +1009,15 @@ void CmidPlayer::rewind(int subsong)
                 if (i) msqtr = 1000000L / i * deltas;
 
                 i=getnexti(2);
-                if (i > 0 && i < flen &&
+                if (i > 0 && (unsigned long)i < flen &&
                     strnlen((char *)data + i, flen - i) < flen - i)
                   title = (char *)data + i;
                 i=getnexti(2);
-                if (i > 0 && i < flen &&
+                if (i > 0 && (unsigned long)i < flen &&
                     strnlen((char *)data + i, flen - i) < flen - i)
                   author = (char *)data + i;
                 i=getnexti(2);
-                if (i > 0 && i < flen &&
+                if (i > 0 && (unsigned long)i < flen &&
                     strnlen((char *)data + i, flen - i) < flen - i)
                   remarks = (char *)data + i;
 

--- a/src/mid.h
+++ b/src/mid.h
@@ -69,7 +69,7 @@ public:
   };
 
   char *author,*title,*remarks,emptystr;
-  long flen;
+  unsigned long flen;
   unsigned long pos;
   unsigned long sierra_pos; //sierras gotta be special.. :>
   int subsongs;
@@ -98,7 +98,7 @@ public:
  private:
   bool load_sierra_ins(const std::string &fname, const CFileProvider &fp);
   void midiprintf(const char *format, ...);
-  unsigned char datalook(long pos);
+  unsigned char datalook(unsigned long pos);
   unsigned long getnexti(unsigned long num);
   unsigned long getnext(unsigned long num);
   void readString(char *dst, unsigned long num);


### PR DESCRIPTION
Fix these warnings:

```
src/mid.cpp: In member function ‘virtual void CmidPlayer::rewind(int)’: src/mid.cpp:995:46: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘long int’ [-Wsign-compare]
  995 |                     if (track[curtrack].tend > flen) // no music after end of file
      |                         ~~~~~~~~~~~~~~~~~~~~~^~~~~~
src/mid.cpp:1013:57: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Wsign-compare]
 1013 |                     strnlen((char *)data + i, flen - i) < flen - i)
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
src/mid.cpp:1017:57: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Wsign-compare]
 1017 |                     strnlen((char *)data + i, flen - i) < flen - i)
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
src/mid.cpp:1021:57: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Wsign-compare]
 1021 |                     strnlen((char *)data + i, flen - i) < flen - i)
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
src/mid.cpp:1108:62: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘long int’ [-Wsign-compare]
 1108 |                 while (datalook(sierra_pos-2) != 0xff && pos < flen)
      |                                                          ~~~~^~~~~~
```