### PR TITLE
Fix for mus-Wsign-compare

### DIFF
--- a/src/mus.cpp
+++ b/src/mus.cpp
@@ -289,7 +289,7 @@ bool CmusPlayer::LoadTimbreBank(const std::string fname, const CFileProvider &fp
 	for (int i = 0; i < nrTimbre; i++)
 	{
 		uint8_t data[ADLIB_INST_LEN];
-		for (int j = 0; j < sizeof(data); j++)
+		for (unsigned int j = 0; j < sizeof(data); j++)
 		{
 			uint16_t val = static_cast<uint16_t>(f->readInt(2));
 			data[j] = val & 0xFF;


### PR DESCRIPTION
Fix this warning:

```
src/mus.cpp: In member function ‘bool CmusPlayer::LoadTimbreBank(std::string, const CFileProvider&)’: src/mus.cpp:292:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  292 |                 for (int j = 0; j < sizeof(data); j++)
      |                                 ~~^~~~~~~~~~~~~~
```