### PR TITLE
Fix for psi-Wsign-compare 

### DIFF
--- a/src/psi.cpp
+++ b/src/psi.cpp
@@ -57,8 +57,8 @@ bool CxadpsiPlayer::xadplayer_load()
   header.instr_ptr = le16(&tune[0]);
   header.seq_ptr = le16(&tune[2]);
 
-  if (header.instr_ptr + psi.nchannels * 2 >= tune_size ||
-      header.seq_ptr + psi.nchannels * 4 >= tune_size)
+  if (header.instr_ptr + (unsigned)psi.nchannels * 2 >= tune_size ||
+      header.seq_ptr + (unsigned)psi.nchannels * 4 >= tune_size)
     return false;
 
   // calculate instruments & sequence tables
@@ -67,7 +67,7 @@ bool CxadpsiPlayer::xadplayer_load()
 
   // validate instrument data & sequence pointers
   for (int i = 0; i < psi.nchannels * 2; i += 2)
-    if (le16(&psi.instr_table[i]) + 11 >= tune_size)
+    if ((unsigned int)le16(&psi.instr_table[i]) + 11 >= tune_size)
       return false;
   for (int i = 0; i < psi.nchannels * 4; i += 2)
     if (le16(&psi.seq_table[i]) >= tune_size)


### PR DESCRIPTION
Fix these warnings:

```
src/psi.cpp: In member function ‘virtual bool CxadpsiPlayer::xadplayer_load()’: src/psi.cpp:60:44: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   60 |   if (header.instr_ptr + psi.nchannels * 2 >= tune_size ||
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
src/psi.cpp:61:42: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   61 |       header.seq_ptr + psi.nchannels * 4 >= tune_size)
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
src/psi.cpp:70:40: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   70 |     if (le16(&psi.instr_table[i]) + 11 >= tune_size)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```