### PR TITLE
Fix for sa2-Wsign-compare 

### DIFF
--- a/src/sa2.cpp
+++ b/src/sa2.cpp
@@ -35,7 +35,7 @@ bool Csa2Loader::load(const std::string &filename, const CFileProvider &fp)
 {
   binistream *f = fp.open(filename); if(!f) return false;
   unsigned char buf;
-  int i,j, k, notedis = 0;
+  unsigned int i,j, k, notedis = 0;
   static const unsigned char convfx[16] = {
     0, 1, 2, 3, 4, 5, 6, 255, 8, 255, 10, 11, 12, 13, 255, 15
   };


### PR DESCRIPTION
Fix this warning:

```
src/sa2.cpp: In member function ‘virtual bool Csa2Loader::load(const string&, const CFileProvider&)’: src/sa2.cpp:137:17: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  137 |   for (i = 0; i < length; i++)  // check order
      |               ~~^~~~~~~~
```