### PR TITLE
Fix for sop-Wsign-compare 

### DIFF
--- a/src/sop.cpp
+++ b/src/sop.cpp
@@ -97,7 +97,7 @@ bool CsopPlayer::load(const std::string &filename, const CFileProvider &fp)
 	nInsts = f->readInt(1);
 	check = f->readInt(1);
 	if (nTracks == 0 || nInsts == 0 || nTracks > SOP_MAX_TRACK || nInsts > SOP_MAX_INST ||
-		check != 0 || fp.filesize(f) < SOP_HEAD_SIZE + nTracks)
+		check != 0 || fp.filesize(f) < (unsigned)SOP_HEAD_SIZE + nTracks)
 	{
 		fp.close(f);
 		return false;
@@ -174,8 +174,8 @@ bool CsopPlayer::load(const std::string &filename, const CFileProvider &fp)
 	}
 	// event tracks
 	track = new sop_trk[nTracks + 1];
-	for (i = 0; i < nTracks + 1; i++) track[i].data = 0;
-	for (i = 0; i < nTracks + 1; i++)
+	for (i = 0; i < (unsigned)nTracks + 1; i++) track[i].data = 0;
+	for (i = 0; i < (unsigned)nTracks + 1; i++)
 	{
 		track[i].nEvents = f->readInt(2);
 		track[i].size = f->readInt(4);


### PR DESCRIPTION
Fix these warnings:

```
src/sop.cpp: In member function ‘virtual bool CsopPlayer::load(const string&, const CFileProvider&)’: src/sop.cpp:100:46: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘int’ [-Wsign-compare]
  100 |                 check != 0 || fp.filesize(f) < SOP_HEAD_SIZE + nTracks)
      |                               ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
src/sop.cpp:177:23: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
  177 |         for (i = 0; i < nTracks + 1; i++) track[i].data = 0;
      |                     ~~^~~~~~~~~~~~~
src/sop.cpp:178:23: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
  178 |         for (i = 0; i < nTracks + 1; i++)
      |                     ~~^~~~~~~~~~~~~
```