### PR TITLE
Fixes for vgm -Wformat-overflow

### DIFF
--- a/src/vgm.cpp
+++ b/src/vgm.cpp
@@ -349,7 +349,7 @@ std::string CvgmPlayer::getdesc()
 	char str_sys[256]; str_sys[0] = 0;
 	if (system[0] && date[0])
 	{
-		sprintf(str_sys, "%s / %s", system, date);
+		snprintf(str_sys, sizeof(str_sys), "%s / %s", system, date);
 	}
 	else if (system[0])
 	{
@@ -365,7 +365,7 @@ std::string CvgmPlayer::getdesc()
 	{
 		if (str_sys[0])
 		{
-			sprintf(str_game, "%s (%s)", game, str_sys);
+			snprintf(str_game, sizeof(str_game), "%s (%s)", game, str_sys);
 		}
 		else
 		{
@@ -378,7 +378,7 @@ std::string CvgmPlayer::getdesc()
 	}
 	if (notes[0])
 	{
-		sprintf(str_desc, "%s\r\n\r\n%s", str_game, notes);
+		snprintf(str_desc, sizeof(str_desc), "%s\r\n\r\n%s", str_game, notes);
 	}
 	else
 	{

--- a/src/vgm.cpp
+++ b/src/vgm.cpp
@@ -347,9 +347,9 @@ std::string CvgmPlayer::getdesc()
 	if (GD3.notes[0])
 		wcstombs(notes, GD3.notes, 256);
 	char str_sys[256]; str_sys[0] = 0;
-	if (system[0] && date[0])
+	if (system[0] && date[0] && strlen(system) <= 251)
 	{
-		snprintf(str_sys, sizeof(str_sys), "%s / %s", system, date);
+		snprintf(str_sys, sizeof(str_sys), "%.251s / %.*s", system, 252 - (int)strlen(system), date);
 	}
 	else if (system[0])
 	{
@@ -363,9 +363,9 @@ std::string CvgmPlayer::getdesc()
 	char str_desc[256]; str_desc[0] = 0;
 	if (game[0])
 	{
-		if (str_sys[0])
+		if (str_sys[0] && strlen(game) <= 251)
 		{
-			snprintf(str_game, sizeof(str_game), "%s (%s)", game, str_sys);
+			snprintf(str_game, sizeof(str_game), "%.251s (%.*s)", game, 252 - (int)strlen(game), str_sys);
 		}
 		else
 		{
@@ -376,9 +376,9 @@ std::string CvgmPlayer::getdesc()
 	{
 		strcpy(str_game, str_sys);
 	}
-	if (notes[0])
+	if (notes[0] && strlen(str_game) <= 250)
 	{
-		snprintf(str_desc, sizeof(str_desc), "%s\r\n\r\n%s", str_game, notes);
+		snprintf(str_desc, sizeof(str_desc), "%.250s\r\n\r\n%.*s", str_game, 251 - (int)strlen(str_game), notes);
 	}
 	else
 	{


### PR DESCRIPTION
These are the warnings we are trying to fix.

Initially these are buffer overflows controlled by the input file, since the target buffer length is not taken into account.

```
src/vgm.cpp: In member function ‘virtual std::string CvgmPlayer::getdesc()’:
src/vgm.cpp:352:37: warning: ‘ / ’ directive writing 3 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
  352 |                 sprintf(str_sys, "%s / %s", system, date);
      |                                     ^~~
src/vgm.cpp:352:24: note: ‘sprintf’ output between 4 and 514 bytes into a destination of size 256
  352 |                 sprintf(str_sys, "%s / %s", system, date);
      |                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/vgm.cpp:368:46: warning: ‘ (’ directive writing 2 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
  368 |                         sprintf(str_game, "%s (%s)", game, str_sys);
      |                                              ^~
src/vgm.cpp:368:32: note: ‘sprintf’ output between 4 and 514 bytes into a destination of size 256
  368 |                         sprintf(str_game, "%s (%s)", game, str_sys);
      |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/vgm.cpp:381:38: warning: ‘

   ’ directive writing 4 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
  381 |                 sprintf(str_desc, "%s\r\n\r\n%s", str_game, notes);
      |                                      ^~~~~~~~
src/vgm.cpp:381:24: note: ‘sprintf’ output between 5 and 515 bytes into a destination of size 256
  381 |                 sprintf(str_desc, "%s\r\n\r\n%s", str_game, notes);
      |                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
