### PR TITLE
Fix for realopl-Wunused-value

### DIFF
--- a/src/realopl.cpp
+++ b/src/realopl.cpp
@@ -46,8 +46,8 @@
   # define INP inb
   # define OUTP(reg,val) outb(val,reg)
 #else // no support on other platforms
-  # define INP(reg)   0
-  # define OUTP(reg, val)
+  static inline int INP(int reg) { return 0; }
+  static inline void OUTP(int reg, int val) { };
 #endif
 
 #include "realopl.h"


### PR DESCRIPTION
Fix these warnings:

```
src/realopl.cpp: In member function ‘bool CRealopl::harddetect()’: src/realopl.cpp:49:23: warning: statement has no effect [-Wunused-value]
   49 |   # define INP(reg)   0
      |                       ^
src/realopl.cpp:95:5: note: in expansion of macro ‘INP’
   95 |     INP(adp);
      |     ^~~
src/realopl.cpp:88:19: warning: unused variable ‘adp’ [-Wunused-variable]
   88 |   unsigned short  adp = (currChip == 0 ? adlport : adlport + 2);
      |                   ^~~
src/realopl.cpp: In member function ‘void CRealopl::hardwrite(int, int)’:
src/realopl.cpp:49:23: warning: statement has no effect [-Wunused-value]
   49 |   # define INP(reg)   0
      |                       ^
src/realopl.cpp:180:5: note: in expansion of macro ‘INP’
  180 |     INP(adp);
      |     ^~~
src/realopl.cpp:49:23: warning: statement has no effect [-Wunused-value]
   49 |   # define INP(reg)   0
      |                       ^
src/realopl.cpp:185:5: note: in expansion of macro ‘INP’
  185 |     INP(adp);
      |     ^~~
src/realopl.cpp:163:18: warning: unused variable ‘adp’ [-Wunused-variable]
  163 |   unsigned short adp = (currChip == 0 ? adlport : adlport + 2);
      |                  ^~~
```