### PR TITLE
Report correct OPL versions

### DIFF
--- a/src/nemuopl.cpp
+++ b/src/nemuopl.cpp
@@ -29,7 +29,7 @@ CNemuopl::CNemuopl(int rate)
 {
   opl = new opl3_chip();
   OPL3_Reset(opl, rate);
-  currType = TYPE_OPL2;
+  currType = TYPE_OPL3;
   samplerate = rate;
 }
 

--- a/src/wemuopl.h
+++ b/src/wemuopl.h
@@ -34,7 +34,7 @@ public:
     : use16bit(bit16), stereo(usestereo), sampleerate(rate)
     {
       opl.adlib_init(rate, usestereo ? 2 : 1, bit16 ? 2 : 1);
-      currType = TYPE_OPL2;
+      currType = TYPE_OPL3;
     };
 
   void update(short *buf, int samples)


### PR DESCRIPTION
This is not actually used anywhere, but the information should still be correct.
 * Nuked is an OPL3 emulator, not OPL2
 * Woody is configured to be OPL3, not OPL2