### PR TITLE
Ensure that variables are set before use (code path is normally not reached)

### DIFF
--- a/src/ksm.cpp
+++ b/src/ksm.cpp
@@ -181,6 +181,7 @@ bool CksmPlayer::update()
 		    case 13: drumnum = 4; chan = 8; break;
 		    case 14: drumnum = 2; chan = 8; break;
 		    case 15: drumnum = 1; chan = 7; freq -= 2048; break;
+		    default: drumnum = 0; chan = 0; break; // should not be reachable
 		    }
 		  databuf[bufnum] = (char)0, bufnum++;
 		  databuf[bufnum] = (unsigned char)(0xa0+chan); bufnum++;

--- a/src/rix.cpp
+++ b/src/rix.cpp
@@ -128,7 +128,7 @@ void CrixPlayer::rewind(int subsong)
   if (flag_mkf && subsong >= 0)
   {
     // changed to actually work and match numbering of getsubsongs()
-    uint32_t i, offset, next, table_end;
+    uint32_t i, offset, next=0, table_end;
     offset = RIX_GET32(file_buffer, 0);
     table_end = offset / 4;
     for (i = 1; i < table_end; i++)


### PR DESCRIPTION
adplug-git/src/ksm.cpp: In member function ‘virtual bool CksmPlayer::update()’: adplug-git/src/ksm.cpp:194:31: warning: ‘drumnum’ may be used uninitialized [-Wmaybe-uninitialized]
  194 |                   drumstat |= drumnum;
      |                               ^~~~~~~
adplug-git/src/ksm.cpp:101:20: note: ‘drumnum’ was declared here
  101 |   int quanter,chan,drumnum,freq,track,volevel,volval;
      |                    ^~~~~~~
adplug-git/src/ksm.cpp:186:57: warning: ‘chan’ may be used uninitialized [-Wmaybe-uninitialized]
  186 |                   databuf[bufnum] = (unsigned char)(0xa0+chan); bufnum++;
      |                                                    ~~~~~^~~~~~
adplug-git/src/ksm.cpp:101:15: note: ‘chan’ was declared here
  101 |   int quanter,chan,drumnum,freq,track,volevel,volval;
      |               ^~~~