### PR TITLE
mid.cpp: Replace std::to_string with compatible solution

### DIFF
--- a/src/mid.cpp
+++ b/src/mid.cpp
@@ -1170,7 +1170,7 @@ std::string CmidPlayer::gettype()
 	case FILE_LUCAS:
 		return std::string("LucasArts AdLib MIDI");
 	case FILE_MIDI:
-		return std::string("General MIDI (type " + std::to_string(midi_type) + ")");
+		return std::string("General MIDI (type " + std::string(1, midi_type | 0x30) + ")");
 	case FILE_CMF:
 		return std::string("Creative Music Format (CMF MIDI)");
 	case FILE_OLDLUCAS:

--- a/src/mid.cpp
+++ b/src/mid.cpp
@@ -1170,7 +1170,8 @@ std::string CmidPlayer::gettype()
 	case FILE_LUCAS:
 		return std::string("LucasArts AdLib MIDI");
 	case FILE_MIDI:
-		return std::string("General MIDI (type " + std::string(1, midi_type | 0x30) + ")");
+		// avoid using std::to_string(midi_type) which is c++11 and may be broken in mingw32
+		return std::string("General MIDI (type " + std::string(1, '0' + midi_type) + ")");
 	case FILE_CMF:
 		return std::string("Creative Music Format (CMF MIDI)");
 	case FILE_OLDLUCAS:


### PR DESCRIPTION
Trivia: older mingw/gcc 4.8.x versions don't have std::to_string implementation.
And since to_string is used only in one sole case in mid.cpp to show the midi_type value, it can be safely replaced with compatible solution.
'midi_type' can hold 0, 1 or 2 only, so we should care only about these values.

Why bother? There are still some cross-toolchains that are nailed to old gcc versions that won't be ever updated. The rest of the code is absolutely 4.8.x compliant, so why not make it slightly more compatible?