### PR TITLE
Fix these warnings: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]

### DIFF
--- a/src/adlibemu.c
+++ b/src/adlibemu.c
@@ -147,7 +147,7 @@ static void docell2 (void *c, float modulator)
 
     ftol(ctc->t+modulator,&i);
 
-    if (*(long *)&ctc->amp <= 0x37800000)
+    if (ctc->amp <= 0.000015258789062f)
     {
 	ctc->amp = 0;
 	ctc->cellfunc = docell4;
@@ -163,7 +163,7 @@ static void docell1 (void *c, float modulator)
 
     ftol(ctc->t+modulator,&i);
 
-    if ((*(long *)&ctc->amp) <= (*(long *)&ctc->sustain))
+    if (ctc->amp <= ctc->sustain)
     {
 	if (ctc->flags&32)
 	{
@@ -186,7 +186,7 @@ static void docell0 (void *c, float modulator)
     ftol(ctc->t+modulator,&i);
 
     ctc->amp = ((ctc->a3*ctc->amp + ctc->a2)*ctc->amp + ctc->a1)*ctc->amp + ctc->a0;
-    if ((*(long *)&ctc->amp) > 0x3f800000)
+    if (ctc->amp > 1.0f)
     {
 	ctc->amp = 1;
 	ctc->cellfunc = docell1;


### PR DESCRIPTION
The given code would not work as expected on big-endian systems, and doing floating point compares on a modern system is not that expensive.