### PR TITLE
Add DJGPP support to Adplug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
         include:
           - compiler: gcc-4.8 # To test compatibility with older systems
             os: ubuntu-latest
+          - compiler: djgpp-2.0.5-gcc-12.2.0 # To test compatibility for Adplay - DOS
+            os: ubuntu-latest
+          - compiler: djgpp-2.0.5-gcc-4.8.5 # To test compatibility for Adplay - DOS
+            os: ubuntu-latest
 
       fail-fast: false
 
@@ -42,6 +46,21 @@ jobs:
           wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-4.8/cpp-4.8_4.8.5-4ubuntu8_amd64.deb
           wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-4.8/libasan0_4.8.5-4ubuntu8_amd64.deb
           sudo apt install ./gcc-4.8_4.8.5-4ubuntu8_amd64.deb ./gcc-4.8-base_4.8.5-4ubuntu8_amd64.deb ./libstdc++-4.8-dev_4.8.5-4ubuntu8_amd64.deb ./cpp-4.8_4.8.5-4ubuntu8_amd64.deb ./libgcc-4.8-dev_4.8.5-4ubuntu8_amd64.deb ./libasan0_4.8.5-4ubuntu8_amd64.deb ./g++-4.8_4.8.5-4ubuntu8_amd64.deb
+        fi
+
+        if [[ ${{ matrix.compiler }} = djgpp* ]]; then
+          # Flex is required, but even though it's in the GitHub runner image, and marked as installed
+          # it's still missing some things, see https://github.com/orgs/community/discussions/45029
+          sudo apt install -y libfl2 libfl-dev
+
+          if [[ ${{ matrix.compiler }} == "djgpp-2.0.5-gcc-12.2.0" ]]; then
+            wget https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
+            bzcat djgpp-linux64-gcc1220.tar.bz2 | sudo tar -x --directory /usr/local
+          fi
+          if [[ ${{ matrix.compiler }} == "djgpp-2.0.5-gcc-4.8.5" ]]; then
+            wget https://github.com/andrewwutw/build-djgpp/releases/download/v1.6/djgpp-linux64-gcc485.tar.bz2
+            bzcat djgpp-linux64-gcc485.tar.bz2 | sudo tar -x --directory /usr/local
+          fi
         fi
 
     - name: Install packages (macOS)
@@ -72,10 +91,16 @@ jobs:
       if: ${{ matrix.compiler == 'clang' }}
       run: echo 'compile_opts=CC=clang CXX=clang++' >> $GITHUB_ENV
 
+    - name: Set DJGPP environment
+      if: ${{ startsWith(matrix.compiler, 'djgpp') }}
+      run: |
+        echo 'compile_opts=--host=i586-pc-msdosdjgpp --prefix=/usr/local/djgpp CXXFLAGS=-Wno-deprecated CPPFLAGS=-Wno-deprecated PKG_CONFIG_PATH=/usr/local/djgpp/lib/pkgconfig' >> $GITHUB_ENV
+        echo 'usr/local//djgpp/bin/' >> $GITHUB_PATH
+
     - name: Install libbinio
       run: |
         git clone http://github.com/adplug/libbinio.git
-        pushd libbinio && autoreconf -i && ./configure --enable-maintainer-mode ${{ env.compile_opts }} && make && sudo make install && popd
+        pushd libbinio && autoreconf -i && ./configure --enable-maintainer-mode ${{ env.compile_opts }} && make && sudo env PATH=$PATH make install && popd
 
     - name: autoreconf
       run: autoreconf -i
@@ -84,22 +109,30 @@ jobs:
 
     - name: make
       run: |
+        ulimit -c unlimited -S
         if [[ ${{ runner.os }} == "macOS" ]]; then
           # - macOS's /usr/bin/texi2dvi is broken
           # - Furthermore, trying to get a working
           #   TeX installation on macOS is a futile
           #   endeavour, hence just run tests.
-          export TARGET=check
+          make check ${{ env.compile_opts }}
+        elif [[ ${{ matrix.compiler }} = djgpp* ]]; then
+          # Just verify it compiles and installs,
+          # we can't run tests because of binary incompatibility with host OS when cross compiling
+
+          # Note: compile_opts is not used here, since DJGPP requires stuff like --host for ./configure
+          # which will mess with make's command-line parsing
+          make all
         elif [[ ${{ runner.os }} == "Linux" ]]; then
-          export TARGET=distcheck
+          make distcheck ${{ env.compile_opts }}
         fi
-        ulimit -c unlimited -S && make "${TARGET}" ${{ env.compile_opts }}
 
     - name: Prepare test results (Linux)
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && !startsWith(matrix.compiler, 'djgpp')}}
       run: make check
 
     - name: Show test results
+      if: ${{ !startsWith(matrix.compiler, 'djgpp')}}
       run: |-
         for I in test/*.log; do
           [ -e "$I" ] || continue

--- a/README
+++ b/README
@@ -19,7 +19,8 @@ platforms and compilers:
 Platform                Operating System        Compiler
 --------                ----------------        --------
 IA32 - x86              Windows XP              MinGW 3.4     # not tested at the moment
-                        MS-DOS 6.22             DJGPP 4.0     # not tested at the moment
+                        MS-DOS 6.22             DJGPP 2.0.5 / GCC 12.2.0
+                        MS-DOS 6.22             DJGPP 2.0.5 / GCC 4.8.5
                         Linux 2.6               GCC 4.1       # not tested at the moment
 x86_64                  Linux                   GCC 4.8
                         Linux                   GCC 11.3.0

--- a/adplugdb/getopt.c
+++ b/adplugdb/getopt.c
@@ -101,7 +101,8 @@
    GNU application programs can use a third alternative mode in which
    they can distinguish the relative order of options and other arguments.  */
 
-#include "getopt.h"
+/* If this file is compiled, it is because our target system is lacking getopt.h */
+#include "mygetopt.h"
 
 /* For communication from `getopt' to the caller.
    When `getopt' finds an option that takes an argument,

--- a/src/composer.h
+++ b/src/composer.h
@@ -36,14 +36,7 @@
 #define ADLIB_OPER_LEN     13		/* operator length, sizeof(SFMOperator) */
 #define ADLIB_INST_LEN     (ADLIB_OPER_LEN * 2 + 2)	/* modulator, carrier, mod/car wave select */
 
-#if !defined(UINT8_MAX)
-    typedef signed char    int8_t;
-    typedef short          int16_t;
-    typedef int            int32_t;
-    typedef unsigned char  uint8_t;
-    typedef unsigned short uint16_t;
-    typedef unsigned int   uint32_t;
-#endif
+#include <stdint.h> // for uintxx_t
 
 #ifdef __x86_64__
     typedef signed   int      int32;

--- a/src/mid.cpp
+++ b/src/mid.cpp
@@ -93,14 +93,7 @@ void CmidPlayer::midiprintf(const char *format, ...)
     }
 #endif
 
-#if !defined(UINT8_MAX)
-typedef signed char    int8_t;
-typedef short          int16_t;
-typedef int            int32_t;
-typedef unsigned char  uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int   uint32_t;
-#endif
+#include <stdint.h> // for uintxx_t
 
 #define LUCAS_STYLE   1
 #define CMF_STYLE     2

--- a/src/rix.cpp
+++ b/src/rix.cpp
@@ -159,7 +159,7 @@ void CrixPlayer::rewind(int subsong)
   data_initial();
 }
 
-uint32_t CrixPlayer::getsubsongs()
+unsigned int CrixPlayer::getsubsongs()
 {
 	if(flag_mkf)
 	{

--- a/src/rix.h
+++ b/src/rix.h
@@ -34,7 +34,7 @@ class CrixPlayer: public CPlayer
   bool update();
   void rewind(int subsong);
   float getrefresh();
-  uint32_t getsubsongs();
+  unsigned int getsubsongs();
   unsigned int getsubsong();
 
   std::string gettype()

--- a/src/vgm.h
+++ b/src/vgm.h
@@ -29,14 +29,7 @@
 
 #include "player.h"
 
-#if !defined(UINT8_MAX)
-typedef signed char    int8_t;
-typedef short          int16_t;
-typedef int            int32_t;
-typedef unsigned char  uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int   uint32_t;
-#endif
+#include <stdint.h> // for uintxx_t
 
 #define VGM_GZIP_MIN	8		// minimum size for GZip header
 #define VGM_HEADER_MIN	84		// minimum size for header (till YM3812 clock field)


### PR DESCRIPTION
Add a few #ifdef preprocessor commands to check for DJGPP being used a compiler for DOS.
Prerequisite PR for PR on Adplay-DOS: https://github.com/adplug/adplay-dos/pull/3