### PR TITLE
IMS: add .kpf as alternate extension

### DIFF
--- a/src/adplug.cpp
+++ b/src/adplug.cpp
@@ -104,7 +104,7 @@ const CPlayerDesc CAdPlug::allplayers[] = {
   CPlayerDesc(ChspLoader::factory, "HSC Packed", ".hsp\0"),
   CPlayerDesc(CksmPlayer::factory, "Ken Silverman Music", ".ksm\0"),
   CPlayerDesc(CmadLoader::factory, "Mlat Adlib Tracker", ".mad\0"),
-  CPlayerDesc(CmusPlayer::factory, "AdLib MIDI/IMS Format", ".mus\0.mdy\0.ims\0"),
+  CPlayerDesc(CmusPlayer::factory, "AdLib MIDI/IMS Format", ".mus\0.mdy\0.ims\0.kpf\0"),
   CPlayerDesc(CmdiPlayer::factory, "AdLib MIDIPlay File", ".mdi\0"),
   CPlayerDesc(CmidPlayer::factory, "MIDI", ".mid\0.sci\0.laa\0"),
   CPlayerDesc(CmkjPlayer::factory, "MKJamz", ".mkj\0"),

--- a/src/mus.h
+++ b/src/mus.h
@@ -59,7 +59,7 @@
 #define SND_HEADER_LEN		6
 #define IMS_SIGNATURE		0x7777
 
-#define KNOWN_MUS_EXT		"mus", "mdy", "ims"
+#define KNOWN_MUS_EXT		"mus", "mdy", "ims", "kpf"
 #define KNOWN_SND_EXT		"snd", "tim", "tbr"
 #define KNOWN_SND_NAME		"", "timbres"
 #define KNOWN_BNK_NAME		"", "implay", "standard"


### PR DESCRIPTION
This is used in Family Production's Shakii: https://moddingwiki.shikadi.net/wiki/Shakii_The_Wolf

A few other Family Production games use different file extensions. Should I add those too?