### PR TITLE
When compiling with mingw, LD needs parameter "-no-undefined" to create shared library (DLL)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,7 @@ src_libadplug_la_SOURCES = \
 	src/xsm.cpp
 
 src_libadplug_la_LDFLAGS = -release $(PACKAGE_VERSION) -version-info 0
+src_libadplug_la_LDFLAGS += -no-undefined # mingw requires this when making shared DLL files
 src_libadplug_la_LIBADD = $(libbinio_LIBS)
 
 # -Dstricmp=strcasecmp is a hack. Throughout AdPlug, stricmp() is used to do


### PR DESCRIPTION
See #205