### PR TITLE
If loading a database and an entry failes to insert, memory was leaked.

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -79,7 +79,13 @@ bool CAdPlugDatabase::load(binistream &f)
 
   // read records
   for(unsigned long i = 0; i < length; i++)
-    insert(CRecord::factory(f));
+  {
+    CRecord *rec = CRecord::factory(f);
+    if (!insert(rec))
+    {
+      delete rec;
+    }
+  }
 
   return true;
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -78,13 +78,10 @@ bool CAdPlugDatabase::load(binistream &f)
   length = f.readInt(4);
 
   // read records
-  for(unsigned long i = 0; i < length; i++)
-  {
+  for(unsigned long i = 0; i < length; i++) {
     CRecord *rec = CRecord::factory(f);
     if (!insert(rec))
-    {
       delete rec;
-    }
   }
 
   return true;


### PR DESCRIPTION
This can happen if you try to load multiple databases, for instance a global database and a user database.