### PR TITLE
Remove all metioning of .MTR from TODO, as the loader has been already implemented

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,9 +13,6 @@ Unfinished items for version 2.3:
 
 General to do items:
 --------------------
-- Add new Protracker loaders:
-  - MTR: Arkham Master Tracker [riven-mage]
-
 - New players:
   - Palladix file format, used in LOGICAL game [dynamite]
 


### PR DESCRIPTION
The loader for .MTR format has been previously implemented, but TODO still marks it as a desired feature.