### PR TITLE
Feature/add memory checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,17 +73,21 @@ jobs:
         #brew install --cask mactex-no-gui
         brew install automake texinfo libtool
 
-    - name: Install LLVM and Clang
+    - name: Install LLVM and Clang (Linux)
       if: ${{ matrix.compiler == 'clang' && runner.os != 'macOS' }}
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "10.0"
 
-    - name: Set GCC-4.8 environment
+    - name: Set GCC environment (Linux)
+      if: ${{ matrix.compiler == 'gcc' && runner.os == 'Linux'}}
+      run: echo "compile_opts=CC=gcc CXX=g++ CXXFLAGS='-fsanitize=address -fsanitize=leak' CPPFLAGS='-fsanitize=address -fsanitize=leak'" >> $GITHUB_ENV
+
+    - name: Set GCC-4.8 environment (Linux)
       if: ${{ matrix.compiler == 'gcc-4.8' }}
       run: echo 'compile_opts=CC=gcc-4.8 CXX=g++-4.8' >> $GITHUB_ENV
 
-    - name: Set GCC environment
+    - name: Set GCC environment (macOS)
       if: ${{ matrix.compiler == 'gcc' && runner.os == 'macOS' }}
       run: echo 'compile_opts=CC=gcc CXX=g++' >> $GITHUB_ENV
 

--- a/src/a2m-v2.cpp
+++ b/src/a2m-v2.cpp
@@ -3592,7 +3592,10 @@ int Ca2mv2Player::a2_read_patterns(char *src, int s, unsigned long size)
         for (int i = 0; i < 4; i++) {
             if (!len[i+s]) continue;
 
-            if (len[i+s] > size) return INT_MAX;
+            if (len[i+s] > size) {
+                free(old);
+                return INT_MAX;
+            }
 
             a2t_depack(src, len[i+s], (char *)old, 16 * sizeof (*old));
 
@@ -3631,7 +3634,10 @@ int Ca2mv2Player::a2_read_patterns(char *src, int s, unsigned long size)
         for (int i = 0; i < 8; i++) {
             if (!len[i+s]) continue;
 
-            if (len[i+s] > size) return INT_MAX;
+            if (len[i+s] > size) {
+                free(old);
+                return INT_MAX;
+            }
 
             a2t_depack(src, len[i+s], (char *)old, 8 * sizeof (*old));
 
@@ -3670,7 +3676,10 @@ int Ca2mv2Player::a2_read_patterns(char *src, int s, unsigned long size)
         // 16 groups of 8 patterns
         for (int i = 0; i < 16; i++) {
             if (!len[i+s]) continue;
-            if (len[i+s] > size) return INT_MAX;
+            if (len[i+s] > size) {
+                free(old);
+                return INT_MAX;
+            }
             a2t_depack(src, len[i+s], (char *)old, 8 * sizeof (*old));
             src += len[i+s];
             size -= len[i+s];


### PR DESCRIPTION
**Memory leaks and memory addressing issues**
This PR adds CI checks for memory leaks and memory addressing issues. It does this by adding `fsanitize=leak` and `fsanitize=address` to regular Linux GCC builds in CI. Note that for all other OS combinations this is **not** done, so there might be rare cases that errors exists with certain combinations of OSes/compilers.

**Issue in a2m-v2**
When enabling this I found a memory leak in the a2m-v2 format parser, where return is called before calling free on allocated memory.