### PR TITLE
Add *.xms as a valid file extension for CamdLoader (The uniqe header signature is already supported)

### DIFF
--- a/src/adplug.cpp
+++ b/src/adplug.cpp
@@ -98,6 +98,7 @@ const CPlayerDesc CAdPlug::allplayers[] = {
   CPlayerDesc(Ca2mv2Player::factory, "Adlib Tracker 2", ".a2m\0.a2t\0"),
   CPlayerDesc(CadtrackLoader::factory, "Adlib Tracker", ".sng\0"),
   CPlayerDesc(CamdLoader::factory, "AMUSIC", ".amd\0"),
+  CPlayerDesc(CamdLoader::factory, "XMS-Tracker", ".xms\0"),
   CPlayerDesc(CbamPlayer::factory, "Bob's Adlib Music", ".bam\0"),
   CPlayerDesc(CcmfPlayer::factory, "Creative Music File", ".cmf\0"),
   CPlayerDesc(CcoktelPlayer::factory, "Coktel Vision Adlib Music", ".adl\0"),


### PR DESCRIPTION
To verify without this patch, simply rename a .xms file into .amd

https://modland.com/pub/modules/Ad%20Lib/AMusic%20XMS/

https://ftp.modland.com/pub/documents/format_documentation/AMusic%20ripp-off%20(.xms).txt

http://justsolve.archiveteam.org/wiki/XMS-Tracker_module