### PR TITLE
[PSI] ensure that le16() works as expected on all architectures (detected by Coverity)

### DIFF
--- a/src/psi.cpp
+++ b/src/psi.cpp
@@ -40,7 +40,7 @@
 
 static unsigned short le16(const unsigned char *p)
 {
-  return ((unsigned short)p[0]) | (((unsigned short)p[1]) << 8);
+  return ((unsigned int)p[0]) | (((unsigned int)p[1]) << 8);
 }
 
 CPlayer *CxadpsiPlayer::factory(Copl *newopl)

--- a/src/psi.cpp
+++ b/src/psi.cpp
@@ -40,7 +40,7 @@
 
 static unsigned short le16(const unsigned char *p)
 {
-  return p[0] | (p[1] << 8);
+  return ((unsigned short)p[0]) | (((unsigned short)p[1]) << 8);
 }
 
 CPlayer *CxadpsiPlayer::factory(Copl *newopl)


### PR DESCRIPTION
(waiting for a new scan to complete)