### PR TITLE
XSM: Provide some background information on the format

### DIFF
--- a/src/xsm.cpp
+++ b/src/xsm.cpp
@@ -17,6 +17,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * xsm.cpp - eXtra Simple Music Player, by Simon Peter <dn.tlp@gmx.net>
+ *
+ * eXtra Simple Music Player can be found in the All BASIC Code archive
+ * package called FMLIB by Davey W. Taylor (SOUND.ABC, 1997).
+ * The ABC archive can be obtained from https://github.com/qb40/abc-archive
+ *
+ * It is a simple (as the name implies ;) package to play FM music using QBasic.
+ * There is no tracker included to produce XSM files, hence it is unlikely that
+ * more XSM files other than the four included demo songs exist.
+ * Davey W. Taylor later went on to write an FM Tracker in QBasic which uses an
+ * incompatible file format.
  */
 
 #include <string.h>


### PR DESCRIPTION
Davey W. Taylor's FM Tracker was the first tracker I used, so I got a bit curious about this other AdLib format of his. Unfortunately, these days all information on this format that can be obtained from present-day search engines points back to AdPlug and software using AdPlug (Davey's website is long gone and it was never archived by archive.org), so I had to do some sleuthing on the famous ABC archive (All BASIC Code, a huge library of BASIC code shared mostly throughout the 90s), and indeed I found an FM-related package by Davey in there (FMLIB). It is the source of the four (and only) XSM files that can be found on ModLand and various other places, and includes the original playback routines (written in BASIC, of course).
I doubt any other XSM files exist because there is no authoring software for them (Davey's FM Tracker uses a structurally similar but incompatible format).

So, since AdPlug seems to be the only place left on the internet that contains indexable information about this format, I'd be happy if these tidbits could be included in the source.