### PR TITLE
A2M-V2: Now proper fix for note-off + tone portamento

### DIFF
--- a/src/a2m-v2.cpp
+++ b/src/a2m-v2.cpp
@@ -265,7 +265,7 @@ void Ca2mv2Player::fmdata_fill_from_raw(tFM_INST_DATA *fm, uint8_t *src)
 // Fill uint8_t data[11] array from tFM_INST_DATA
 void Ca2mv2Player::raw_fill_from_fmdata(uint8_t *dst, tFM_INST_DATA *fm)
 {
-dst[0] = (fm->multipM & 0xf) |
+    dst[0] = (fm->multipM & 0xf) |
             ((fm->ksrM  & 1) << 4) |
             ((fm->sustM & 1) << 5) |
             ((fm->vibrM & 1) << 6) |
@@ -1476,10 +1476,11 @@ void Ca2mv2Player::process_effects(tADTRACK2_EVENT *event, int slot, int chan)
     case ef_TonePortamento:
         update_effect_table(slot, chan, EFGR_TONEPORTAMENTO, def, val);
 
-        if (!(event->note & keyoff_flag) && note_in_range(event->note)) {
+        if (note_in_range(event->note)) {
             ch->porta_table[slot][chan].speed = val;
-            ch->porta_table[slot][chan].freq = nFreq(event->note - 1) +
-                get_instr_fine_tune(ch->event_table[chan].instr_def);
+            if (!(event->note & keyoff_flag))
+                ch->porta_table[slot][chan].freq = nFreq(event->note - 1) +
+                    get_instr_fine_tune(ch->event_table[chan].instr_def);
         } else {
             ch->porta_table[slot][chan].speed = ch->effect_table[slot][chan].val;
         }


### PR DESCRIPTION
Hi, this is the fix of a fix for the following case:
![image](https://github.com/user-attachments/assets/67ee3468-944e-4bce-8081-4df9fa0d7833)

Previously, if note-off happened, the current portamento effect value was discarded and the previous value from the previous row was used. This worked because in most cases note portamento has the same value on all rows.

However, there could be potentially a case when different values are used on each row, so the new and correct logic is: in case of note-off command use the current effect value. This affects fank5.a2m, however, it's hard to hear the difference.