### PR TITLE
Stresstest omit on windows platform (configure/automake)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -252,23 +252,26 @@ doc/adplugdb.1: $(top_srcdir)/doc/adplugdb.1.in
 check_PROGRAMS = \
 	test/playtest \
 	test/emutest \
-	test/crctest \
-	test/strstest
+	test/crctest
 
 test_playtest_SOURCES = test/playertest.cpp
 test_emutest_SOURCES = test/emutest.cpp
 test_crctest_SOURCES = test/crctest.cpp
-test_strstest_SOURCES = test/stresstest.cpp
 
 test_playtest_CPPFLAGS = $(libbinio_CFLAGS)
 test_emutest_CPPFLAGS = $(libbinio_CFLAGS)
 test_crctest_CPPFLAGS = $(libbinio_CFLAGS)
-test_strstest_CPPFLAGS = $(libbinio_CFLAGS)
 
 test_playtest_LDADD = src/libadplug.la $(libbinio_LIBS)
 test_emutest_LDADD = src/libadplug.la $(libbinio_LIBS)
 test_crctest_LDADD = src/libadplug.la $(libbinio_LIBS)
+
+if !WINDOWS
+check_PROGRAMS += test/strstest
+test_strstest_SOURCES = test/stresstest.cpp
+test_strstest_CPPFLAGS = $(libbinio_CFLAGS)
 test_strstest_LDADD = src/libadplug.la $(libbinio_LIBS)
+endif
 
 AM_TESTS_ENVIRONMENT = testdir='$(srcdir)/test'; export testdir;
 TESTS = $(check_PROGRAMS)

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,9 @@ dnl Sanitize some compiler features, which may be broken...
 AC_C_CONST
 AC_C_INLINE
 
+dnl Check whether we are compiling for Windows (MinGW or Cygwin)
+AM_CONDITIONAL([WINDOWS], [echo "$host_os" | grep -iq 'mingw\|cygwin'])
+
 AC_CONFIG_FILES([
     Makefile
     src/version.h


### PR DESCRIPTION
Trivia:
test/stresstest.cpp is very unix-specific and is not directly portable to Windows.
Since it is already omitted in cmake files and msvs project files, it is natural to ignore it on windows platform.

What this fix does:
Eliminates stresstest.cpp from building on Windows platform (mingw/cygwin variants), so 'make check' passes without problems