### PR TITLE
XMI: Reorder initializer to match class declaration to remove compiler warnings

### DIFF
--- a/src/xmi.cpp
+++ b/src/xmi.cpp
@@ -255,11 +255,11 @@ CxmiPlayer::CxmiPlayer(Copl *newopl)
     , author_len(0)
     , ext_bank_data(0)
     , ext_bank_size(0)
-    , current_chip(-1)
-    , nrpn(0)
     , cache_mem(0)
     , cache_size(0)
     , cache_end(0)
+    , nrpn(0)
+    , current_chip(-1)
 {
     cache_mem = new uint8_t[XMI_CACHE_SIZE];
 }


### PR DESCRIPTION
Fixes these warnings. I build adplug statically into a plugin, so I get verbose messages when compiling.

```
In file included from adplug-git/src/xmi.cpp:35:
adplug-git/src/xmi.h: In constructor ‘CxmiPlayer::CxmiPlayer(Copl*)’:
adplug-git/src/xmi.h:295:9: warning: ‘CxmiPlayer::current_chip’ will be initialized after [-Wreorder]
  295 |     int current_chip;
      |         ^~~~~~~~~~~~
adplug-git/src/xmi.h:238:14: warning:   ‘int32_t CxmiPlayer::nrpn’ [-Wreorder]
  238 |     int32_t  nrpn;
      |              ^~~~
adplug-git/src/xmi.cpp:246:1: warning:   when initialized here [-Wreorder]
  246 | CxmiPlayer::CxmiPlayer(Copl *newopl)
      | ^~~~~~~~~~
adplug-git/src/xmi.h:238:14: warning: ‘CxmiPlayer::nrpn’ will be initialized after [-Wreorder]
  238 |     int32_t  nrpn;
      |              ^~~~
adplug-git/src/xmi.h:226:14: warning:   ‘uint8_t* CxmiPlayer::cache_mem’ [-Wreorder]
  226 |     uint8_t *cache_mem;
      |              ^~~~~~~~~
adplug-git/src/xmi.cpp:246:1: warning:   when initialized here [-Wreorder]
  246 | CxmiPlayer::CxmiPlayer(Copl *newopl)
      | ^~~~~~~~~~
```