### PR TITLE
AMD: Properly handle zero-length order

### DIFF
--- a/src/amd.cpp
+++ b/src/amd.cpp
@@ -84,7 +84,7 @@ bool CamdLoader::load(const std::string &filename, const CFileProvider &fp)
   // order length + # of patterns
   length = f->readInt(1);
   nop = f->readInt(1) + 1;
-  if (length > 128 || nop > 64) {
+  if (length == 0 || length > 128 || nop > 64) {
     fp.close(f);
     return false;
   }


### PR DESCRIPTION
Hi.
When running stresstest on Windows I've spotted this subtle bug in amd.cpp
It turned out that on certain files from test/fuzzing the stresstest got stuck instead of being killed properly. This become noticeable on Windows, because MingGW doesn't provide alarm() function, and the behavior has to be emulated with other means.

Files with 0 length order:
i-110_072.amd
i-110_086.amd
i-110_109.amd
i-110_152.amd
i-110_169.amd

They slipped past the length > 128 check, the order-validation loop never ran, and the player later read from random location. All five are now rejected at load time.

i-110_109 and i-110_169 → now picked up by the LucasArts AdLib MIDI loader instead
i-110_072.amd is a renamed midi, and happen to have the zero-length order, but it was not loading as AMD in the original code either, so the amd fix doesn't change its observable behavior.