### PR TITLE
CI: Bump GitHub Actions versions to avoid deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install packages (Linux)
       if: ${{ runner.os == 'Linux' }}
@@ -270,7 +270,7 @@ jobs:
 
     - name: Upload failed test output
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: adplug-tests-${{runner.os}}-${{matrix.compiler}}-${{github.sha}}
         path: |

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -27,7 +27,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Checkout libbinio repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         repository: '${{env.LIBBINIO_REPOSITORY}}'
         ref: master
@@ -35,7 +35,7 @@ jobs:
         fetch-depth: 0
 
     - name: Checkout adplug repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: adplug
         fetch-depth: 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Checkout libbinio repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         repository: '${{env.LIBBINIO_REPOSITORY}}'
         ref: master
@@ -61,7 +61,7 @@ jobs:
         fetch-depth: 0
 
     - name: Checkout adplug repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: adplug
         fetch-depth: 0

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -26,7 +26,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Checkout libbinio repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         repository: '${{env.LIBBINIO_REPOSITORY}}'
         ref: master
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 0
 
     - name: Checkout adplug repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: adplug
         fetch-depth: 0

--- a/.github/workflows/msvc-scan.yml
+++ b/.github/workflows/msvc-scan.yml
@@ -25,7 +25,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Checkout libbinio repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         repository: '${{env.LIBBINIO_REPOSITORY}}'
         ref: master
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 0
 
     - name: Checkout adplug repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: adplug
         fetch-depth: 0


### PR DESCRIPTION
This PR bumps the versions of the CI GitHub Actions, to avoid deprecation warnings about Node (for example see annotations of [recent build logs](https://github.com/adplug/adplug/actions/runs/28396382396))