### PR TITLE
CI: Add check for forks where to find libbinio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,12 @@ jobs:
 
     - name: Install libbinio
       run: |
-        git clone http://github.com/adplug/libbinio.git
+        owner="${GITHUB_REPOSITORY%/*}"
+        repo="adplug/libbinio"
+        if [ "$owner" != "adplug" ] && git ls-remote --exit-code "https://github.com/$owner/libbinio.git" >/dev/null 2>&1; then
+          repo="$owner/libbinio"
+        fi
+        git clone "https://github.com/$repo.git"
         pushd libbinio && autoreconf -i && ./configure --enable-maintainer-mode ${{ env.compile_opts }} ${{ env.compile_env }} && make ${{ env.compile_env }} && sudo env PATH=$PATH make install && popd
 
     - name: autoreconf

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -18,7 +18,13 @@ jobs:
     steps:
     - name: Find libbinio repository
       shell: bash
-      run: echo LIBBINIO_REPOSITORY="${GITHUB_REPOSITORY%/adplug}/libbinio" >> $GITHUB_ENV
+      run: |
+        owner="${GITHUB_REPOSITORY%/*}"
+        if [ "$owner" = "adplug" ] || git ls-remote --exit-code "https://github.com/$owner/libbinio.git" >/dev/null 2>&1; then
+          echo "LIBBINIO_REPOSITORY=$owner/libbinio" >> "$GITHUB_ENV"
+        else
+          echo 'LIBBINIO_REPOSITORY=adplug/libbinio' >> "$GITHUB_ENV"
+        fi
 
     - name: Get cmake and ninja
       uses: lukka/get-cmake@latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,13 @@ jobs:
     steps:
     - name: Find libbinio repository
       shell: bash
-      run: echo LIBBINIO_REPOSITORY="${GITHUB_REPOSITORY%/adplug}/libbinio" >> $GITHUB_ENV
+      run: |
+        owner="${GITHUB_REPOSITORY%/*}"
+        if [ "$owner" = "adplug" ] || git ls-remote --exit-code "https://github.com/$owner/libbinio.git" >/dev/null 2>&1; then
+          echo "LIBBINIO_REPOSITORY=$owner/libbinio" >> "$GITHUB_ENV"
+        else
+          echo 'LIBBINIO_REPOSITORY=adplug/libbinio' >> "$GITHUB_ENV"
+        fi
 
     - name: Get cmake and ninja
       uses: lukka/get-cmake@latest

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -17,7 +17,13 @@ jobs:
     steps:
     - name: Find libbinio repository
       shell: bash
-      run: echo LIBBINIO_REPOSITORY="${GITHUB_REPOSITORY%/adplug}/libbinio" >> $GITHUB_ENV
+      run: |
+        owner="${GITHUB_REPOSITORY%/*}"
+        if [ "$owner" = "adplug" ] || git ls-remote --exit-code "https://github.com/$owner/libbinio.git" >/dev/null 2>&1; then
+          echo "LIBBINIO_REPOSITORY=$owner/libbinio" >> "$GITHUB_ENV"
+        else
+          echo 'LIBBINIO_REPOSITORY=adplug/libbinio' >> "$GITHUB_ENV"
+        fi
 
     - name: Get cmake and ninja
       uses: lukka/get-cmake@latest

--- a/.github/workflows/msvc-scan.yml
+++ b/.github/workflows/msvc-scan.yml
@@ -16,7 +16,13 @@ jobs:
     steps:
     - name: Find libbinio repository
       shell: bash
-      run: echo LIBBINIO_REPOSITORY="${GITHUB_REPOSITORY%/adplug}/libbinio" >> $GITHUB_ENV
+      run: |
+        owner="${GITHUB_REPOSITORY%/*}"
+        if [ "$owner" = "adplug" ] || git ls-remote --exit-code "https://github.com/$owner/libbinio.git" >/dev/null 2>&1; then
+          echo "LIBBINIO_REPOSITORY=$owner/libbinio" >> "$GITHUB_ENV"
+        else
+          echo 'LIBBINIO_REPOSITORY=adplug/libbinio' >> "$GITHUB_ENV"
+        fi
 
     - name: Get cmake and ninja
       uses: lukka/get-cmake@latest


### PR DESCRIPTION
Current CI (except autotools) assumes libbinio is always present as fork under the organization running the CI (for example if I fork adplug, it assumes libbinio is under `AranVink/libbinio`). This assumption breaks CI for most workflows when forking.

This PR fixes this by adding an if statement to check who is the owner, and if it's a fork, try a git remote ls to check if the forker also has libbinio forked.