### PR TITLE
A2M-V2: Properly reset tick variables in rewind()

### DIFF
--- a/src/a2m-v2.cpp
+++ b/src/a2m-v2.cpp
@@ -108,6 +108,8 @@ void Ca2mv2Player::rewind(int subsong)
     pattern_delay = false;
     tickXF = 0;
     ticks = 0;
+    tick0 = 0;
+    tickD = 0;
     next_line = 0;
     irq_mode = true;
     play_status = isPlaying;


### PR DESCRIPTION
Hi.
Noticed that multiple calls of rewind() while the player has played some time may induce silence after rewinding, because not all tick variables were properly cleared.
Now they are, no random silence after rewind().

This wasn't noticeable with adplay, but may surface up when using other player with progressbar that allows positioning to any moment in the music file.