### PR TITLE
CMF: Silence CID 649070: Insecure data handling  (INTEGER_OVERFLOW)

### DIFF
--- a/src/cmf.cpp
+++ b/src/cmf.cpp
@@ -938,7 +938,7 @@ void CcmfPlayer::cmfNoteOn(uint8_t iChannel, uint8_t iNote, uint8_t iVelocity)
 		// 0xC0 handler), so a stale instrument can never linger here.
 		int iPrevOwner = this->chOPL[iOPLChannel].iMIDIChannel;
 		if (iPrevOwner != (int)iChannel) {
-			this->MIDIchangeInstrument(iOPLChannel, iChannel, this->chMIDI[iChannel].iPatch);
+			this->MIDIchangeInstrument((uint8_t)iOPLChannel, iChannel, this->chMIDI[iChannel].iPatch);
 		}
 
 		this->chOPL[iOPLChannel].iNoteStart = ++this->iNoteCount;


### PR DESCRIPTION
Shut down this warning:
````
** CID 649070:       Insecure data handling  (INTEGER_OVERFLOW)


_____________________________________________________________________________________________
*** CID 649070:         Insecure data handling  (INTEGER_OVERFLOW)
/src/cmf.cpp: 941             in CcmfPlayer::cmfNoteOn(unsigned char, unsigned char, unsigned char)()
935     		// Reprogram the instrument only if this voice was last owned by a different
936     		// MIDI channel, exactly as fmdrv does (it compares the previous owner, not
937     		// the patch number).  Program changes invalidate parked voices (see the
938     		// 0xC0 handler), so a stale instrument can never linger here.
939     		int iPrevOwner = this->chOPL[iOPLChannel].iMIDIChannel;
940     		if (iPrevOwner != (int)iChannel) {
>>>     CID 649070:         Insecure data handling  (INTEGER_OVERFLOW)
>>>     "iOPLChannel", which might have overflowed, is passed to "this->MIDIchangeInstrument(iOPLChannel, iChannel, this->chMIDI[iChannel].iPatch)".
941     			this->MIDIchangeInstrument(iOPLChannel, iChannel, this->chMIDI[iChannel].iPatch);
942     		}
943     
944     		this->chOPL[iOPLChannel].iNoteStart = ++this->iNoteCount;
945     		this->chOPL[iOPLChannel].iMIDIChannel = iChannel;
946     		this->chOPL[iOPLChannel].iMIDINote = iNote;
````

